### PR TITLE
feat : 사진들 get 구현

### DIFF
--- a/src/main/java/com/usememo/jugger/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/controller/PhotoController.java
@@ -1,0 +1,33 @@
+package com.usememo.jugger.domain.photo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.usememo.jugger.domain.photo.dto.GetPhotoDto;
+import com.usememo.jugger.domain.photo.dto.GetPhotoRequestDto;
+import com.usememo.jugger.domain.photo.repository.PhotoRepository;
+import com.usememo.jugger.domain.photo.service.PhotoService;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PhotoController {
+
+	private final PhotoService photoService;
+
+	@GetMapping("/photos")
+	public Flux<GetPhotoDto> getPhotos(
+		@RequestParam String user_uuid,
+		@RequestParam String category_uuid){
+		return photoService.getPhotoDto(GetPhotoRequestDto.builder()
+			.userUuid(user_uuid)
+			.categoryUuid(category_uuid)
+			.build());
+	}
+}

--- a/src/main/java/com/usememo/jugger/domain/photo/dto/GetPhotoDto.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/dto/GetPhotoDto.java
@@ -1,0 +1,12 @@
+package com.usememo.jugger.domain.photo.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GetPhotoDto {
+	private String url;
+}

--- a/src/main/java/com/usememo/jugger/domain/photo/dto/GetPhotoRequestDto.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/dto/GetPhotoRequestDto.java
@@ -1,0 +1,11 @@
+package com.usememo.jugger.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GetPhotoRequestDto {
+	private String userUuid;
+	private String categoryUuid;
+}

--- a/src/main/java/com/usememo/jugger/domain/photo/dto/PhotoDto.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/dto/PhotoDto.java
@@ -1,0 +1,14 @@
+package com.usememo.jugger.domain.photo.dto;
+
+import org.springframework.http.codec.multipart.FilePart;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class PhotoDto {
+	private String user_uuid;
+	private String category_uuid;
+	private FilePart filePart;
+}

--- a/src/main/java/com/usememo/jugger/domain/photo/entity/Photo.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/entity/Photo.java
@@ -3,14 +3,17 @@ package com.usememo.jugger.domain.photo.entity;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @Document(collection = "photos")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class Photo {
 	@Id
 	@Field("photo_uuid")

--- a/src/main/java/com/usememo/jugger/domain/photo/entity/Photo.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/entity/Photo.java
@@ -2,6 +2,7 @@ package com.usememo.jugger.domain.photo.entity;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,8 +13,15 @@ import lombok.Builder;
 @Builder
 public class Photo {
 	@Id
-	private String photo_uuid;
-	private String user_uuid;
+	@Field("photo_uuid")
+	private String photoUuid;
+
+	@Field("user_uuid")
+	private String userUuid;
+
+	@Field("url")
 	private String url;
-	private String category_uuid;
+
+	@Field("category_uuid")
+	private String categoryUuid;
 }

--- a/src/main/java/com/usememo/jugger/domain/photo/entity/Photo.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/entity/Photo.java
@@ -12,9 +12,8 @@ import lombok.Builder;
 @Builder
 public class Photo {
 	@Id
-	private String uuid;
-	private String userUuid;
-	private String chatUuid;
+	private String photo_uuid;
+	private String user_uuid;
 	private String url;
-	private String categoryUuid;
+	private String category_uuid;
 }

--- a/src/main/java/com/usememo/jugger/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/repository/PhotoRepository.java
@@ -4,5 +4,8 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 
 import com.usememo.jugger.domain.photo.entity.Photo;
 
+import reactor.core.publisher.Flux;
+
 public interface PhotoRepository extends ReactiveMongoRepository<Photo, String> {
+	Flux<Photo> findByUserUuidAndCategoryUuid(String userUuid, String categoryUuid);
 }

--- a/src/main/java/com/usememo/jugger/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/service/PhotoService.java
@@ -1,0 +1,11 @@
+package com.usememo.jugger.domain.photo.service;
+
+import com.usememo.jugger.domain.photo.dto.GetPhotoDto;
+import com.usememo.jugger.domain.photo.dto.GetPhotoRequestDto;
+import com.usememo.jugger.domain.photo.dto.PhotoDto;
+
+import reactor.core.publisher.Flux;
+
+public interface PhotoService {
+	Flux<GetPhotoDto> getPhotoDto(GetPhotoRequestDto photoRequestDto);
+}

--- a/src/main/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementation.java
@@ -1,0 +1,26 @@
+package com.usememo.jugger.domain.photo.service;
+
+import org.springframework.stereotype.Service;
+
+import com.usememo.jugger.domain.photo.dto.GetPhotoDto;
+import com.usememo.jugger.domain.photo.dto.GetPhotoRequestDto;
+import com.usememo.jugger.domain.photo.repository.PhotoRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoServiceImplementation implements  PhotoService{
+
+	private final PhotoRepository photoRepository;
+
+	public Flux<GetPhotoDto> getPhotoDto(GetPhotoRequestDto photoRequestDto){
+		return photoRepository
+			.findByUserUuidAndCategoryUuid(photoRequestDto.getUserUuid(), photoRequestDto.getCategoryUuid())
+			.map(photo -> GetPhotoDto.builder()
+				.url(photo.getUrl())
+				.build());
+	}
+
+}

--- a/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
@@ -19,7 +19,7 @@ import reactor.core.publisher.Mono;
 public class S3Controller {
 	private final S3ServiceImplementation s3ServiceImplementation;
 
-	@PostMapping(value = "/test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PostMapping(value = "/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public Mono<ResponseEntity<String>> upload(@RequestPart("file") FilePart file) {
 		return s3ServiceImplementation.uploadFile(file)
 			.map(url -> ResponseEntity.ok(url));

--- a/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.usememo.jugger.domain.photo.dto.PhotoDto;
 import com.usememo.jugger.global.s3.service.S3ServiceImplementation;
 
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,18 @@ public class S3Controller {
 	private final S3ServiceImplementation s3ServiceImplementation;
 
 	@PostMapping(value = "/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public Mono<ResponseEntity<String>> upload(@RequestPart("file") FilePart file) {
-		return s3ServiceImplementation.uploadFile(file)
+	public Mono<ResponseEntity<String>> upload(
+		@RequestPart("file") FilePart file,
+		@RequestPart("user_uuid") String userUuid,
+		@RequestPart("category_uuid") String categoryUuid
+	) {
+		PhotoDto dto = PhotoDto.builder()
+			.user_uuid(userUuid)
+			.category_uuid(categoryUuid)
+			.filePart(file)
+			.build();
+
+		return s3ServiceImplementation.uploadFile(dto)
 			.map(url -> ResponseEntity.ok(url));
 	}
 }

--- a/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.usememo.jugger.domain.photo.dto.PhotoDto;
+import com.usememo.jugger.global.s3.service.S3Service;
 import com.usememo.jugger.global.s3.service.S3ServiceImplementation;
 
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/api/upload")
 @RequiredArgsConstructor
 public class S3Controller {
-	private final S3ServiceImplementation s3ServiceImplementation;
+	private final S3Service s3Service;
 
 	@PostMapping(value = "/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public Mono<ResponseEntity<String>> upload(
@@ -32,7 +33,7 @@ public class S3Controller {
 			.filePart(file)
 			.build();
 
-		return s3ServiceImplementation.uploadFile(dto)
+		return s3Service.uploadFile(dto)
 			.map(url -> ResponseEntity.ok(url));
 	}
 }

--- a/src/main/java/com/usememo/jugger/global/s3/service/S3Service.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3Service.java
@@ -2,8 +2,10 @@ package com.usememo.jugger.global.s3.service;
 
 import org.springframework.http.codec.multipart.FilePart;
 
+import com.usememo.jugger.domain.photo.dto.PhotoDto;
+
 import reactor.core.publisher.Mono;
 
 public interface S3Service {
-	Mono<String> uploadFile(FilePart filePart);
+	Mono<String> uploadFile(PhotoDto photoDto);
 }

--- a/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
@@ -57,8 +57,8 @@ public class S3ServiceImplementation implements S3Service{
 	private Mono<Boolean> savePhoto(String saveUrl,String user_uuid, String category_uuid){
 		return photoRepository.save(Photo.builder()
 				.url(saveUrl)
-				.user_uuid(user_uuid)
-				.category_uuid(category_uuid)
+				.userUuid(user_uuid)
+				.categoryUuid(category_uuid)
 				.build())
 			.map(saved -> true)
 			.onErrorReturn(false);

--- a/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
@@ -53,7 +53,7 @@ public class S3ServiceImplementation implements S3Service{
 				}
 			});
 	}
-	//DB에 저장하는 함수
+
 	private Mono<Boolean> savePhoto(String saveUrl,String user_uuid, String category_uuid){
 		return photoRepository.save(Photo.builder()
 				.url(saveUrl)

--- a/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
@@ -14,6 +14,9 @@ import reactor.core.publisher.Mono;
 import java.io.InputStream;
 import java.util.UUID;
 
+import com.usememo.jugger.domain.photo.dto.PhotoDto;
+import com.usememo.jugger.domain.photo.entity.Photo;
+import com.usememo.jugger.domain.photo.repository.PhotoRepository;
 import com.usememo.jugger.global.exception.s3.S3UploadException;
 
 @Service
@@ -21,22 +24,43 @@ import com.usememo.jugger.global.exception.s3.S3UploadException;
 public class S3ServiceImplementation implements S3Service{
 
 	private final S3Template s3Template;
+	private final PhotoRepository photoRepository;
 	@Value("${spring.cloud.aws.s3.bucket}")
 	private String bucketName;
 
-	public Mono<String> uploadFile(FilePart filePart) {
-		String originalFilename = filePart.filename();
+
+	public Mono<String> uploadFile(PhotoDto photoDto) {
+		String originalFilename = photoDto.getFilePart().filename();
 		String ext = originalFilename.substring(originalFilename.lastIndexOf("."));
 		String newFileName = UUID.randomUUID() + ext;
 
-		return DataBufferUtils.join(filePart.content())
+		return DataBufferUtils.join(photoDto.getFilePart().content())
 			.flatMap(dataBuffer -> {
 				try (InputStream inputStream = dataBuffer.asInputStream()) {
 					s3Template.upload(bucketName, newFileName, inputStream);
-					return Mono.just("https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + newFileName);
+					String saveUrl = "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + newFileName;
+
+					return savePhoto(saveUrl, photoDto.getUser_uuid(), photoDto.getCategory_uuid())
+						.flatMap(success -> {
+							if (success) {
+								return Mono.just(saveUrl);
+							} else {
+								return Mono.error(new S3UploadException());
+							}
+						});
 				} catch (Exception e) {
 					return Mono.error(new S3UploadException());
 				}
 			});
+	}
+	//DB에 저장하는 함수
+	private Mono<Boolean> savePhoto(String saveUrl,String user_uuid, String category_uuid){
+		return photoRepository.save(Photo.builder()
+				.url(saveUrl)
+				.user_uuid(user_uuid)
+				.category_uuid(category_uuid)
+				.build())
+			.map(saved -> true)
+			.onErrorReturn(false);
 	}
 }

--- a/src/test/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementationTest.java
+++ b/src/test/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementationTest.java
@@ -1,0 +1,52 @@
+package com.usememo.jugger.domain.photo.service;
+
+import com.usememo.jugger.domain.photo.dto.GetPhotoDto;
+import com.usememo.jugger.domain.photo.dto.GetPhotoRequestDto;
+import com.usememo.jugger.domain.photo.entity.Photo;
+import com.usememo.jugger.domain.photo.repository.PhotoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+class PhotoServiceImplementationTest {
+
+	@Test
+	@DisplayName("Photo 목록을 조회하고 Dto로 변환")
+	void getPhotoDto_shouldReturnFluxOfGetPhotoDto() {
+		// given
+		PhotoRepository photoRepository = mock(PhotoRepository.class);
+		PhotoServiceImplementation photoService = new PhotoServiceImplementation(photoRepository);
+
+		String userUuid = "user1";
+		String categoryUuid = "여행";
+		String url1 = "https://s3.amazon.com/photo1.jpg";
+		String url2 = "https://s3.amazon.com/photo2.jpg";
+
+		Photo photo1 = Photo.builder().url(url1).build();
+		Photo photo2 = Photo.builder().url(url2).build();
+
+		when(photoRepository.findByUserUuidAndCategoryUuid(userUuid, categoryUuid))
+			.thenReturn(Flux.just(photo1, photo2));
+
+		GetPhotoRequestDto requestDto = GetPhotoRequestDto.builder()
+			.userUuid(userUuid)
+			.categoryUuid(categoryUuid)
+			.build();
+
+		// when
+		Flux<GetPhotoDto> result = photoService.getPhotoDto(requestDto);
+
+		// then
+		StepVerifier.create(result)
+			.expectNext(GetPhotoDto.builder().url(url1).build())
+			.expectNext(GetPhotoDto.builder().url(url2).build())
+			.verifyComplete();
+
+		verify(photoRepository, times(1)).findByUserUuidAndCategoryUuid(userUuid, categoryUuid);
+	}
+}

--- a/src/test/java/com/usememo/jugger/global/s3/service/S3ServiceImplementationTest.java
+++ b/src/test/java/com/usememo/jugger/global/s3/service/S3ServiceImplementationTest.java
@@ -8,6 +8,7 @@ import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.test.util.ReflectionTestUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.io.InputStream;
@@ -16,6 +17,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import com.usememo.jugger.domain.photo.dto.PhotoDto;
+import com.usememo.jugger.domain.photo.entity.Photo;
+import com.usememo.jugger.domain.photo.repository.PhotoRepository;
+
 class S3ServiceImplementationTest {
 
 	@Test
@@ -23,7 +28,8 @@ class S3ServiceImplementationTest {
 	void uploadFile_shouldReturnUrl_whenSuccessful() {
 		// given
 		S3Template s3Template = mock(S3Template.class);
-		S3ServiceImplementation s3ServiceImplementation = new S3ServiceImplementation(s3Template);
+		PhotoRepository photoRepository = mock(PhotoRepository.class);
+		S3ServiceImplementation s3ServiceImplementation = new S3ServiceImplementation(s3Template, photoRepository);
 
 		String testBucketName = "jugger-bucket";
 		ReflectionTestUtils.setField(s3ServiceImplementation, "bucketName", testBucketName);
@@ -31,21 +37,33 @@ class S3ServiceImplementationTest {
 		FilePart filePart = mock(FilePart.class);
 		when(filePart.filename()).thenReturn("test-image.jpg");
 
+		String category_uuid = "jugger-category";
+		String user_uuid = "user1";
+
 		DataBuffer dataBuffer = new DefaultDataBufferFactory().wrap("fake-image-content".getBytes());
 		when(filePart.content()).thenReturn(Flux.just(dataBuffer));
 
 		when(s3Template.upload(eq(testBucketName), any(String.class), any(InputStream.class)))
-			.thenReturn(null);
+			.thenReturn(null); // 실제 업로드는 void or null로 처리됨
+
+		// ✅ DB 저장 mocking 추가!
+		Photo mockPhoto = mock(Photo.class);
+		when(photoRepository.save(any(Photo.class))).thenReturn(Mono.just(mockPhoto));
 
 		// when & then
-		StepVerifier.create(s3ServiceImplementation.uploadFile(filePart))
+		StepVerifier.create(s3ServiceImplementation.uploadFile(
+				PhotoDto.builder()
+					.category_uuid(category_uuid)
+					.user_uuid(user_uuid)
+					.filePart(filePart)
+					.build()))
 			.assertNext(url -> {
 				assert url.startsWith("https://" + testBucketName + ".s3.ap-northeast-2.amazonaws.com/");
 				assert url.endsWith(".jpg");
 			})
 			.verifyComplete();
 
-		verify(s3Template, times(1))
-			.upload(eq(testBucketName), any(String.class), any(InputStream.class));
+		verify(s3Template, times(1)).upload(eq(testBucketName), any(String.class), any(InputStream.class));
+		verify(photoRepository, times(1)).save(any(Photo.class));
 	}
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #43 

## 📝 요약(Summary)
<img width="1066" alt="스크린샷 2025-04-09 오전 12 33 56" src="https://github.com/user-attachments/assets/97a2258c-31c7-4992-a2c5-a9ef7775c094" />

이렇게 user_uuid와 category_uuid를 입력받아서 유저와 카테고리에 일치하는 사진들을 url형태로 구현해주는 방식으로 구현하였습니다!


## 💬 공유사항 to 리뷰어
<img width="598" alt="스크린샷 2025-04-09 오전 12 35 13" src="https://github.com/user-attachments/assets/83a5a9e6-0441-419d-a077-3146aeee016e" />
이렇게 user_uuid도 저장하는 식으로 수정하였습니다!

그렇기에 user_uuid와 category_uuid로 쉽게 찾아서 이미지를 불러오는 시간을 궁극적으로 줄일 수 있을 것 같아 이렇게 수정하였습니다!

<img width="453" alt="스크린샷 2025-04-09 오전 12 38 13" src="https://github.com/user-attachments/assets/61dc9f26-c2fb-458a-a7ea-2339bbe69223" />
또한 field를 원래 도메인 구조 설계했던대로 user_uuid와 같은 스네이크 케이스로 구현해두었습니다! 
## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).