### PR TITLE
refactor : 사진 post 기능 수정

### DIFF
--- a/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
@@ -24,11 +24,10 @@ public class S3Controller {
 	@PostMapping(value = "/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public Mono<ResponseEntity<String>> upload(
 		@RequestPart("file") FilePart file,
-		@RequestPart("user_uuid") String userUuid,
 		@RequestPart("category_uuid") String categoryUuid
 	) {
 		PhotoDto dto = PhotoDto.builder()
-			.user_uuid(userUuid)
+			.user_uuid("123456789a")
 			.category_uuid(categoryUuid)
 			.filePart(file)
 			.build();

--- a/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
 @RestController
-@RequestMapping("/api/upload")
+@RequestMapping("/api/v1/upload")
 @RequiredArgsConstructor
 public class S3Controller {
 	private final S3Service s3Service;


### PR DESCRIPTION
## #️⃣ Issue Number

- #48 

## 📝 요약(Summary)
<img width="1082" alt="스크린샷 2025-04-14 오전 3 02 09" src="https://github.com/user-attachments/assets/e31dae29-dc32-48ef-b6e6-6d6a1399634e" />
user_uuid를 하드코딩해서 넣음으로써 위의 사진과 같이 file과 category_uuid만 전달하면 동작하도록 수정하였습니다.

<img width="275" alt="스크린샷 2025-04-14 오전 3 02 49" src="https://github.com/user-attachments/assets/56739ab9-d285-4f72-9430-0178ada4a17f" />
추가로 api 경로를 수정하였습니다.

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).