### PR TITLE
feat : 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,18 +25,22 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 //    implementation 'software.amazon.awssdk:s3:2.31.15'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
-//	testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'

--- a/src/main/java/com/usememo/jugger/domain/user/entity/User.java
+++ b/src/main/java/com/usememo/jugger/domain/user/entity/User.java
@@ -7,10 +7,12 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 
 @Document(collection = "users")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class User {
 	@Id
 	private String uuid;

--- a/src/main/java/com/usememo/jugger/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/usememo/jugger/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.usememo.jugger.domain.user.repository;
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+import com.usememo.jugger.domain.user.entity.User;
+
+import reactor.core.publisher.Mono;
+
+public interface UserRepository extends ReactiveMongoRepository<User,String> {
+	Mono<User> findByEmail(String email);
+
+}

--- a/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
+++ b/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
@@ -28,9 +28,6 @@ public class SecurityConfig {
 				.pathMatchers("/", "/login/**", "/oauth2/**", "/auth/**").permitAll()
 				.anyExchange().authenticated()
 			)
-			.oauth2Login(oauth2 -> oauth2
-				.authenticationSuccessHandler(successHandler)
-			)
 			.build();
 	}
 }

--- a/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
+++ b/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.usememo.jugger.global.config;
+
+import com.usememo.jugger.global.security.CustomOAuth2UserService;
+import com.usememo.jugger.global.security.JwtTokenProvider;
+import com.usememo.jugger.global.security.OAuth2AuthenticationSuccessHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+	private final CustomOAuth2UserService customOAuth2UserService;
+
+	public SecurityConfig(CustomOAuth2UserService customOAuth2UserService) {
+		this.customOAuth2UserService = customOAuth2UserService;
+	}
+
+	@Bean
+	public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,OAuth2AuthenticationSuccessHandler successHandler) {
+		return http
+			.csrf(ServerHttpSecurity.CsrfSpec::disable)
+			.authorizeExchange(exchange -> exchange
+				.pathMatchers("/", "/login/**", "/oauth2/**", "/auth/**").permitAll()
+				.anyExchange().authenticated()
+			)
+			.oauth2Login(oauth2 -> oauth2
+				.authenticationSuccessHandler(successHandler)
+			)
+			.build();
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
+++ b/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
@@ -10,7 +10,10 @@ import lombok.Getter;
 public enum ErrorCode {
 	CATEGORY_ALREADY_EXIST(BAD_REQUEST, 400, "이미 존재하는 카테고리입니다"),
 	CATEGORY_IS_NULL(BAD_REQUEST, 400, "카테고리는 NULL값일 수 없습니다"),
-	FILE_UPLOAD_FAIL(INTERNAL_SERVER_ERROR, 500, "S3 파일 업로드에 실패했습니다.");
+	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "S3 파일 업로드에 실패했습니다."),
+	NO_REFRESH_TOKEN(UNAUTHORIZED,400,"리프레시 토큰이 없습니다."),
+	EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,400, "만료된 토큰입니다"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다.");
 
 	private final HttpStatus httpStatus;
 	private final int code;

--- a/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.usememo.jugger.global.exception.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.usememo.jugger.global.exception.BaseException;
+import com.usememo.jugger.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Order(-2)
+@RequiredArgsConstructor
+public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+		ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+		if (ex instanceof BaseException) {
+			errorCode = ((BaseException) ex).getErrorCode();
+		}
+
+		exchange.getResponse().setStatusCode(errorCode.getHttpStatus());
+		exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+		Map<String, Object> response = new HashMap<>();
+		response.put("code", errorCode.getCode());
+		response.put("message", errorCode.getMessage());
+
+		DataBufferFactory bufferFactory = exchange.getResponse().bufferFactory();
+
+		try {
+			byte[] bytes = objectMapper.writeValueAsBytes(response);
+			return exchange.getResponse().writeWith(Mono.just(bufferFactory.wrap(bytes)));
+		} catch (Exception e) {
+			byte[] fallback = "예외 처리 중 오류가 발생했습니다.".getBytes(StandardCharsets.UTF_8);
+			return exchange.getResponse().writeWith(Mono.just(bufferFactory.wrap(fallback)));
+		}
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.usememo.jugger.global.exception.handler;
+package com.usememo.jugger.global.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
@@ -26,10 +26,10 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
 	private final ObjectMapper objectMapper;
 
 	@Override
-	public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+	public Mono<Void> handle(ServerWebExchange exchange, Throwable exception) {
 		ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-		if (ex instanceof BaseException) {
-			errorCode = ((BaseException) ex).getErrorCode();
+		if (exception instanceof BaseException) {
+			errorCode = ((BaseException) exception).getErrorCode();
 		}
 
 		exchange.getResponse().setStatusCode(errorCode.getHttpStatus());

--- a/src/main/java/com/usememo/jugger/global/security/CustomOAuth2User.java
+++ b/src/main/java/com/usememo/jugger/global/security/CustomOAuth2User.java
@@ -1,0 +1,37 @@
+package com.usememo.jugger.global.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+	private final Map<String, Object> attributes;
+	private final String uuid;
+
+	public CustomOAuth2User(Map<String, Object> attributes, String uuid) {
+		this.attributes = attributes;
+		this.uuid = uuid;
+	}
+
+	public String getUserId() {
+		return uuid;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public String getName() {
+		return uuid;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(() -> "ROLE_USER");
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/usememo/jugger/global/security/CustomOAuth2UserService.java
@@ -1,0 +1,41 @@
+package com.usememo.jugger.global.security;
+
+import com.usememo.jugger.domain.user.entity.User;
+import com.usememo.jugger.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultReactiveOAuth2UserService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public Mono<OAuth2User> loadUser(OAuth2UserRequest userRequest) {
+		return super.loadUser(userRequest)
+			.flatMap(oAuth2User -> {
+				Map<String, Object> attributes = oAuth2User.getAttributes();
+				String email = (String) attributes.get("email");
+				String name = (String) attributes.get("name");
+				String domain = userRequest.getClientRegistration().getRegistrationId();
+
+				return userRepository.findByEmail(email)
+					.switchIfEmpty(
+						userRepository.save(User.builder()
+							.email(email)
+							.name(name)
+							.domain(domain)
+							.terms(new User.Terms())
+							.build())
+					)
+					.map(user -> new CustomOAuth2User(attributes, user.getUuid()));
+			});
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.usememo.jugger.global.security;
 import static io.jsonwebtoken.security.Keys.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
@@ -22,12 +23,12 @@ public class JwtTokenProvider {
 	private String SECRET_KEY;
 
 	@Value("${spring.jwt.access-token-duration}")
-
+	private Duration accessTokenDuration;
 	private final MacAlgorithm alg = Jwts.SIG.HS512;
 
 	public String createAccessToken(UUID userId) {
 		Date now = new Date();
-		Date expiryDate = new Date(now.getTime() + 3600000);
+		Date expiryDate = new Date(now.getTime() + accessTokenDuration.toMillis() );
 
 
 		SecretKey key = hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
@@ -1,0 +1,77 @@
+package com.usememo.jugger.global.security;
+
+import static io.jsonwebtoken.security.Keys.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.MacAlgorithm;
+import javax.crypto.SecretKey;
+
+
+@Component
+public class JwtTokenProvider {
+	@Value("${spring.jwt.secret}")
+	private String SECRET_KEY;
+
+	private final MacAlgorithm alg = Jwts.SIG.HS512;
+
+	public String createAccessToken(UUID userId) {
+		Date now = new Date();
+		Date expiryDate = new Date(now.getTime() + 3600000);
+
+
+		SecretKey key = hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+
+		return Jwts.builder()
+			.claims(Map.of("sub",userId.toString() ))
+			.issuedAt(now)
+			.expiration(expiryDate)
+			.signWith(key, alg)
+			.compact();
+	}
+
+	public String createRefreshToken(UUID userId, long validityMillis){
+		Date now = new Date();
+		Date expiryDate = new Date(now.getTime() + validityMillis);
+		SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+
+		return Jwts.builder()
+			.claims(Map.of("sub",userId.toString()))
+			.issuedAt(now)
+			.expiration(expiryDate)
+			.signWith(key,alg)
+			.compact();
+	}
+
+	public String getUserIdFromToken(String token){
+
+		return Jwts.parser()
+			.verifyWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
+			.build()
+			.parseSignedClaims(token)
+			.getPayload()
+			.getSubject();
+	}
+
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parser()
+				.verifyWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
+				.build()
+				.parseSignedClaims(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
@@ -21,6 +21,8 @@ public class JwtTokenProvider {
 	@Value("${spring.jwt.secret}")
 	private String SECRET_KEY;
 
+	@Value("${spring.jwt.access-token-duration}")
+
 	private final MacAlgorithm alg = Jwts.SIG.HS512;
 
 	public String createAccessToken(UUID userId) {

--- a/src/main/java/com/usememo/jugger/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/usememo/jugger/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,73 @@
+package com.usememo.jugger.global.security;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import lombok.NonNull;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.usememo.jugger.global.security.token.domain.RefreshToken;
+import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
+
+@Component
+public class OAuth2AuthenticationSuccessHandler implements ServerAuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(7);
+
+	public OAuth2AuthenticationSuccessHandler(JwtTokenProvider jwtTokenProvider,RefreshTokenRepository refreshTokenRepository) {
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.refreshTokenRepository = refreshTokenRepository;
+	}
+
+	@Override
+	public Mono<Void> onAuthenticationSuccess(@NonNull WebFilterExchange webFilterExchange, @NonNull Authentication authentication) {
+		ServerWebExchange exchange = webFilterExchange.getExchange();
+
+		CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+		UUID userId = UUID.fromString(oAuth2User.getUserId());
+
+		String accessToken = jwtTokenProvider.createAccessToken(userId);
+
+		String refreshToken = jwtTokenProvider.createRefreshToken(userId,REFRESH_TOKEN_DURATION.toMillis());
+
+		RefreshToken tokenDoc = RefreshToken.builder()
+			.userId(userId)
+			.token(refreshToken)
+			.expiryDate(Instant.now().plus(REFRESH_TOKEN_DURATION))
+			.build();
+		ResponseCookie cookie = ResponseCookie.from("refresh_token",refreshToken)
+			.httpOnly(true)
+			.secure(true)
+			.path("/")
+			.maxAge(REFRESH_TOKEN_DURATION)
+			.sameSite("Strict")
+			.build();
+
+
+
+		byte[] body = ("{\"accessToken\":\"" + accessToken + "\"}").getBytes(StandardCharsets.UTF_8);
+
+		exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+		exchange.getResponse().getCookies().add("refresh_token",cookie);
+		exchange.getResponse().setStatusCode(HttpStatus.OK);
+
+		return refreshTokenRepository.save(tokenDoc)
+			.then(exchange.getResponse().writeWith(
+				Mono.just(exchange.getResponse().bufferFactory().wrap(body))
+			));
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/usememo/jugger/global/security/OAuth2AuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.usememo.jugger.global.security;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
@@ -26,7 +27,8 @@ public class OAuth2AuthenticationSuccessHandler implements ServerAuthenticationS
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RefreshTokenRepository refreshTokenRepository;
 
-	private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(7);
+	@Value("${spring.jwt.refresh-token-duration}")
+	private  Duration REFRESH_TOKEN_DURATION;
 
 	public OAuth2AuthenticationSuccessHandler(JwtTokenProvider jwtTokenProvider,RefreshTokenRepository refreshTokenRepository) {
 		this.jwtTokenProvider = jwtTokenProvider;
@@ -38,11 +40,11 @@ public class OAuth2AuthenticationSuccessHandler implements ServerAuthenticationS
 		ServerWebExchange exchange = webFilterExchange.getExchange();
 
 		CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-		UUID userId = UUID.fromString(oAuth2User.getUserId());
+		String userId = oAuth2User.getUserId();
 
 		String accessToken = jwtTokenProvider.createAccessToken(userId);
 
-		String refreshToken = jwtTokenProvider.createRefreshToken(userId,REFRESH_TOKEN_DURATION.toMillis());
+		String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
 		RefreshToken tokenDoc = RefreshToken.builder()
 			.userId(userId)

--- a/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
@@ -1,23 +1,22 @@
 package com.usememo.jugger.global.security.token.controller;
 
-import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.usememo.jugger.domain.user.repository.UserRepository;
-import com.usememo.jugger.global.security.CustomOAuth2User;
 import com.usememo.jugger.global.security.JwtTokenProvider;
+import com.usememo.jugger.global.security.token.domain.TokenResponse;
 import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
+import com.usememo.jugger.global.security.token.service.KakaoOAuthService;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -29,6 +28,7 @@ public class AuthController {
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final UserRepository userRepository;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final KakaoOAuthService kakaoService;
 
 	@PostMapping(value = "/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<ResponseEntity<String>> refreshAccessToken(@CookieValue(name = "refresh_token",required = false) String refreshToken){
@@ -43,7 +43,7 @@ public class AuthController {
 					String userId = jwtTokenProvider.getUserIdFromToken(savedToken.getToken());
 					return userRepository.findById(userId)
 						.map(user->{
-							String newAccessToken = jwtTokenProvider.createAccessToken(UUID.fromString(userId));
+							String newAccessToken = jwtTokenProvider.createAccessToken(userId);
 							return ResponseEntity.ok().body("{\"accessToken\":\""+newAccessToken+"\"}");
 						});
 			})
@@ -62,11 +62,6 @@ public class AuthController {
 		} catch (Exception e) {
 			return Mono.just(ResponseEntity.noContent().build());
 		}
-		//프론트에서 인가 코드를 받아서 -> 코드를 서버가 가져서 카카오에 요청을 받아서 처리하는 것이다.
-		//사용자 정보를 저장하는 형식인 것이다.
-		//프론트에 jwt 토큰을 넘겨주면 되는 것이다.
-		//redirection 때문에 문제가 발생하는 것이다.
-		//security 설정해서 이대로 쓰기
 		return refreshTokenRepository.deleteByUserId(UUID.fromString(userId))
 			.thenReturn(ResponseEntity
 				.noContent()
@@ -81,11 +76,10 @@ public class AuthController {
 				.build());
 	}
 
-	// @GetMapping("/success")
-	// public Mono<ResponseEntity<Map<String, String>>> loginSuccess(Authentication authentication) {
-	// 	CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
-	// 	String accessToken = jwtTokenProvider.createAccessToken(UUID.fromString(user.getUserId()));
-	// 	return Mono.just(ResponseEntity.ok(Map.of("accessToken", accessToken)));
-	// }
+	@PostMapping("/kakao")
+	public Mono<ResponseEntity<TokenResponse>> loginByKakao(@RequestParam String code) {
+		return kakaoService.loginWithKakao(code)
+			.map(token -> ResponseEntity.ok().body(token));
+	}
 
 }

--- a/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
 	@PostMapping("/logout")
 	public Mono<ResponseEntity<Void>> logout(@CookieValue(name = "refresh_token", required = false) String refreshToken) {
 		if (refreshToken == null) {
-			return Mono.just(ResponseEntity.noContent().build()); // 쿠키 없으면 무시
+			return Mono.just(ResponseEntity.noContent().build());
 		}
 
 		String userId;
@@ -62,7 +62,11 @@ public class AuthController {
 		} catch (Exception e) {
 			return Mono.just(ResponseEntity.noContent().build());
 		}
-
+		//프론트에서 인가 코드를 받아서 -> 코드를 서버가 가져서 카카오에 요청을 받아서 처리하는 것이다.
+		//사용자 정보를 저장하는 형식인 것이다.
+		//프론트에 jwt 토큰을 넘겨주면 되는 것이다.
+		//redirection 때문에 문제가 발생하는 것이다.
+		//security 설정해서 이대로 쓰기
 		return refreshTokenRepository.deleteByUserId(UUID.fromString(userId))
 			.thenReturn(ResponseEntity
 				.noContent()
@@ -70,7 +74,6 @@ public class AuthController {
 					.httpOnly(true)
 					.secure(true)
 					.path("/")
-					.sameSite("None")
 					.maxAge(0)
 					.build()
 					.toString()
@@ -78,11 +81,11 @@ public class AuthController {
 				.build());
 	}
 
-	@GetMapping("/success")
-	public Mono<ResponseEntity<Map<String, String>>> loginSuccess(Authentication authentication) {
-		CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
-		String accessToken = jwtTokenProvider.createAccessToken(UUID.fromString(user.getUserId()));
-		return Mono.just(ResponseEntity.ok(Map.of("accessToken", accessToken)));
-	}
+	// @GetMapping("/success")
+	// public Mono<ResponseEntity<Map<String, String>>> loginSuccess(Authentication authentication) {
+	// 	CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
+	// 	String accessToken = jwtTokenProvider.createAccessToken(UUID.fromString(user.getUserId()));
+	// 	return Mono.just(ResponseEntity.ok(Map.of("accessToken", accessToken)));
+	// }
 
 }

--- a/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
@@ -1,0 +1,88 @@
+package com.usememo.jugger.global.security.token.controller;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.usememo.jugger.domain.user.repository.UserRepository;
+import com.usememo.jugger.global.security.CustomOAuth2User;
+import com.usememo.jugger.global.security.JwtTokenProvider;
+import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@PostMapping(value = "/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
+	public Mono<ResponseEntity<String>> refreshAccessToken(@CookieValue(name = "refresh_token",required = false) String refreshToken){
+		if(refreshToken == null){
+			return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("리프레시 토큰이 없습니다"));
+		}
+		return refreshTokenRepository.findByToken(refreshToken)
+			.flatMap(savedToken->{
+				if(!jwtTokenProvider.validateToken(savedToken.getToken())){
+					return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("만료된 리프레시 토큰입니다."));
+				}
+					String userId = jwtTokenProvider.getUserIdFromToken(savedToken.getToken());
+					return userRepository.findById(userId)
+						.map(user->{
+							String newAccessToken = jwtTokenProvider.createAccessToken(UUID.fromString(userId));
+							return ResponseEntity.ok().body("{\"accessToken\":\""+newAccessToken+"\"}");
+						});
+			})
+			.switchIfEmpty(Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("존재하지 않는 리프레시 토큰입니다.")));
+	}
+
+	@PostMapping("/logout")
+	public Mono<ResponseEntity<Void>> logout(@CookieValue(name = "refresh_token", required = false) String refreshToken) {
+		if (refreshToken == null) {
+			return Mono.just(ResponseEntity.noContent().build()); // 쿠키 없으면 무시
+		}
+
+		String userId;
+		try {
+			userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+		} catch (Exception e) {
+			return Mono.just(ResponseEntity.noContent().build());
+		}
+
+		return refreshTokenRepository.deleteByUserId(UUID.fromString(userId))
+			.thenReturn(ResponseEntity
+				.noContent()
+				.header("Set-Cookie", ResponseCookie.from("refresh_token", "")
+					.httpOnly(true)
+					.secure(true)
+					.path("/")
+					.sameSite("None")
+					.maxAge(0)
+					.build()
+					.toString()
+				)
+				.build());
+	}
+
+	@GetMapping("/success")
+	public Mono<ResponseEntity<Map<String, String>>> loginSuccess(Authentication authentication) {
+		CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
+		String accessToken = jwtTokenProvider.createAccessToken(UUID.fromString(user.getUserId()));
+		return Mono.just(ResponseEntity.ok(Map.of("accessToken", accessToken)));
+	}
+
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoOAuthProperties.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoOAuthProperties.java
@@ -1,0 +1,17 @@
+package com.usememo.jugger.global.security.token.domain;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Configuration
+@ConfigurationProperties(prefix = "kakao")
+@Getter
+@Setter
+public class KakaoOAuthProperties {
+	private String clientId;
+	private String clientSecret;
+	private String redirectUri;
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoUserResponse.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoUserResponse.java
@@ -1,0 +1,22 @@
+package com.usememo.jugger.global.security.token.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserResponse {
+	private Long id;
+	private KakaoAccount kakaoAccount;
+	private Properties properties;
+
+	@Getter @Setter
+	public static class KakaoAccount {
+		private String email;
+	}
+
+	@Getter @Setter
+	public static class Properties {
+		private String nickname;
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/RefreshToken.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/RefreshToken.java
@@ -1,0 +1,26 @@
+package com.usememo.jugger.global.security.token.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document
+public class RefreshToken {
+
+	@Id
+	private String id;
+	private UUID userId;
+	private String token;
+	private Instant expiryDate;
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/RefreshToken.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/RefreshToken.java
@@ -20,7 +20,7 @@ public class RefreshToken {
 
 	@Id
 	private String id;
-	private UUID userId;
+	private String userId;
 	private String token;
 	private Instant expiryDate;
 }

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/TokenResponse.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.usememo.jugger.global.security.token.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+	private String accessToken;
+	private String refreshToken;
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.usememo.jugger.global.security.token.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+import com.usememo.jugger.global.security.token.domain.RefreshToken;
+
+import reactor.core.publisher.Mono;
+
+public interface RefreshTokenRepository extends ReactiveCrudRepository<RefreshToken,String> {
+	Mono<RefreshToken> findByToken(String token);
+	Mono<Void> deleteByUserId(UUID UserId);
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/service/KakaoOAuthService.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/service/KakaoOAuthService.java
@@ -1,0 +1,69 @@
+package com.usememo.jugger.global.security.token.service;
+
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.usememo.jugger.domain.user.entity.User;
+import com.usememo.jugger.domain.user.repository.UserRepository;
+import com.usememo.jugger.global.security.JwtTokenProvider;
+import com.usememo.jugger.global.security.token.domain.KakaoOAuthProperties;
+import com.usememo.jugger.global.security.token.domain.KakaoUserResponse;
+import com.usememo.jugger.global.security.token.domain.TokenResponse;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+	private final WebClient webClient = WebClient.create();
+	private final KakaoOAuthProperties kakaoProps;
+	private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public Mono<TokenResponse> loginWithKakao(String code) {
+		return getAccessToken(code)
+			.flatMap(this::getUserInfo)
+			.flatMap(this::saveOrFindUser)
+			.map(user -> jwtTokenProvider.createTokenBundle(user.getUuid()));
+	}
+
+	private Mono<String> getAccessToken(String code) {
+		return webClient.post()
+			.uri("https://kauth.kakao.com/oauth/token")
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.body(BodyInserters.fromFormData("grant_type", "authorization_code")
+				.with("client_id", kakaoProps.getClientId())
+				.with("redirect_uri", kakaoProps.getRedirectUri())
+				.with("code", code))
+			.retrieve()
+			.bodyToMono(Map.class)
+			.map(body -> (String) body.get("access_token"));
+	}
+
+	private Mono<KakaoUserResponse> getUserInfo(String accessToken) {
+		return webClient.get()
+			.uri("https://kapi.kakao.com/v2/user/me")
+			.headers(headers -> headers.setBearerAuth(accessToken))
+			.retrieve()
+			.bodyToMono(KakaoUserResponse.class);
+	}
+
+	private Mono<User> saveOrFindUser(KakaoUserResponse response) {
+		String email = response.getKakaoAccount().getEmail();
+		String name = response.getProperties().getNickname();
+
+		return userRepository.findByEmail(email)
+			.switchIfEmpty(userRepository.save(User.builder()
+				.email(email)
+				.name(name)
+				.domain("kakao")
+				.terms(new User.Terms()) // 약관은 따로 받으면 됨
+				.build()));
+	}
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- #47 

## 📝 요약(Summary)
현재까지의 진행상황은 OAuth2를 통해서 정보를 받고 JWT access token과 refresh token을 발급해주는 형태로 구현해두었습니다.
추가로 각 소셜미디어별로 파싱하는 부분과 application.yml 부분에만 추가하면 제대로 동작할 것 같습니다.
webflux로 진행하다보니 생각보다 다른 부분이 많아서 오래걸렸습니다!

## 💬 공유사항 to 리뷰어
지금 코드를 받으시면 에러가 발생할 것입니다!!
application.yml 설정과 kakao 전용 parser를 아직 설정하지 않아서 그렇습니다.
일단 빠른 개발이 필요한만큼 개발현황을 공유하는게 좋을 것 같아서 pr올립니다.

또한 하나 고민해볼 사안이 프론트에서 카카오에 요청을 받고 user 정보를 서버에 넘겨줘서 이걸 저장하고 토큰을 발급해주는 식으로 할지, 아니면 현재 제가 코드를 작성한대로 클라이언트의 요청에 따라 백엔드에서 카카오에 요청을 보내 정보를 가져오는 식으로 구현할지 고민해봐야 할 것 같습니다!

+ webflux에서 global exception handler 만들어본 것은 처음이라 제대로 동작하는지 테스트 필요합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).