### PR TITLE
feat: 카테고리 핀 설정,해제 API

### DIFF
--- a/src/main/java/com/usememo/jugger/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/usememo/jugger/domain/category/controller/CategoryController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.mongodb.client.result.UpdateResult;
 import com.usememo.jugger.domain.category.dto.GetRecentCategoryDto;
 import com.usememo.jugger.domain.category.dto.PostCategoryDto;
 import com.usememo.jugger.domain.category.entity.Category;
@@ -68,10 +69,21 @@ public class CategoryController {
 
 	}
 
+	@Operation(summary = "[GET] 최근 채팅한 카테고리 조회 (사이드바 용)")
 	@GetMapping("/recent")
 	public Mono<ResponseEntity<List<GetRecentCategoryDto>>> getRecentCategories() {
 		return categoryService.getRecentCategories()
 			.collectList()
 			.map(ResponseEntity::ok);
+	}
+
+	@Operation(summary = "[POST] 카테고리 핀 설정/해제")
+	@PostMapping("/pin")
+	public Mono<ResponseEntity<UpdateResult>> pinCategory(String categoryId, boolean isPinned) {
+		return categoryService.pinCategory(categoryId, isPinned)
+			.map(savedPin -> ResponseEntity
+				.status(HttpStatus.OK)
+				.body(savedPin));
+
 	}
 }

--- a/src/main/java/com/usememo/jugger/domain/category/entity/Category.java
+++ b/src/main/java/com/usememo/jugger/domain/category/entity/Category.java
@@ -21,4 +21,8 @@ public class Category extends BaseTimeEntity {
 	private String color;
 	private Boolean isPinned;
 	private String userUuid;
+
+	public void setPinned(Boolean pinned) {
+		isPinned = pinned;
+	}
 }

--- a/src/main/java/com/usememo/jugger/domain/category/service/CategoryService.java
+++ b/src/main/java/com/usememo/jugger/domain/category/service/CategoryService.java
@@ -1,5 +1,6 @@
 package com.usememo.jugger.domain.category.service;
 
+import com.mongodb.client.result.UpdateResult;
 import com.usememo.jugger.domain.category.dto.GetRecentCategoryDto;
 import com.usememo.jugger.domain.category.dto.PostCategoryDto;
 import com.usememo.jugger.domain.category.entity.Category;
@@ -12,5 +13,7 @@ public interface CategoryService {
 	Mono<Category> createCategory(PostCategoryDto postCategoryDto);
 
 	Flux<GetRecentCategoryDto> getRecentCategories();
+
+	Mono<UpdateResult> pinCategory(String categoryId, boolean isPinned);
 }
 

--- a/src/main/java/com/usememo/jugger/domain/category/service/CategoryServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/category/service/CategoryServiceImplementation.java
@@ -2,8 +2,13 @@ package com.usememo.jugger.domain.category.service;
 
 import java.util.UUID;
 
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
+import com.mongodb.client.result.UpdateResult;
 import com.usememo.jugger.domain.category.dto.GetRecentCategoryDto;
 import com.usememo.jugger.domain.category.dto.PostCategoryDto;
 import com.usememo.jugger.domain.category.entity.Category;
@@ -20,6 +25,8 @@ import reactor.core.publisher.Mono;
 public class CategoryServiceImplementation implements CategoryService {
 	private final CategoryRepository categoryRepository;
 	private final ChatService chatService;
+
+	private final ReactiveMongoTemplate reactiveMongoTemplate;
 
 	private final String tempUuid = "123456789a";
 
@@ -51,6 +58,14 @@ public class CategoryServiceImplementation implements CategoryService {
 						.updateAt(category.getUpdatedAt())
 						.recentMessage(chat != null ? chat.getData() : null)
 						.build()));
+	}
+
+	@Override
+	public Mono<UpdateResult> pinCategory(String categoryId, boolean isPinned) {
+		Query query = Query.query(Criteria.where("uuid").is(categoryId));
+		Update update = new Update().set("isPinned", isPinned);
+		return reactiveMongoTemplate.updateFirst(query, update, Category.class);
+
 	}
 
 }

--- a/src/main/java/com/usememo/jugger/global/config/ReactiveMongoConfig.java
+++ b/src/main/java/com/usememo/jugger/global/config/ReactiveMongoConfig.java
@@ -1,0 +1,20 @@
+package com.usememo.jugger.global.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+
+@Configuration
+public class ReactiveMongoConfig {
+
+	@Autowired
+	MongoClient mongoClient;
+
+	@Bean
+	public ReactiveMongoTemplate reactiveMongoTemplate() {
+		return new ReactiveMongoTemplate(mongoClient, "jugger");
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
+++ b/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
 					"/webjars/**",
-					"/favicon.ico"
+					"/favicon.ico",
+					"/docs"
 				)
 				.permitAll()
 				.anyExchange()

--- a/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
+++ b/src/main/java/com/usememo/jugger/global/config/SecurityConfig.java
@@ -1,14 +1,13 @@
 package com.usememo.jugger.global.config;
 
-import com.usememo.jugger.global.security.CustomOAuth2UserService;
-import com.usememo.jugger.global.security.JwtTokenProvider;
-import com.usememo.jugger.global.security.OAuth2AuthenticationSuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+
+import com.usememo.jugger.global.security.CustomOAuth2UserService;
+import com.usememo.jugger.global.security.OAuth2AuthenticationSuccessHandler;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -21,13 +20,27 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,OAuth2AuthenticationSuccessHandler successHandler) {
+	public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
+		OAuth2AuthenticationSuccessHandler successHandler) {
 		return http
 			.csrf(ServerHttpSecurity.CsrfSpec::disable)
 			.authorizeExchange(exchange -> exchange
-				.pathMatchers("/", "/login/**", "/oauth2/**", "/auth/**").permitAll()
-				.anyExchange().authenticated()
+				.pathMatchers(
+					"/",
+					"/login/**",
+					"/oauth2/**",
+					"/auth/**",
+					"/swagger-ui.html",
+					"/swagger-ui/**",
+					"/v3/api-docs/**",
+					"/webjars/**",
+					"/favicon.ico"
+				)
+				.permitAll()
+				.anyExchange()
+				.authenticated()
 			)
+
 			.build();
 	}
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #57 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 카테고리에 핀 설정 및 해제하는 API입니다!
![image](https://github.com/user-attachments/assets/8c23c1b6-4427-4b46-b69d-98ba935a554e)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
https://docs.spring.io/spring-data/mongodb/reference/mongodb/repositories/query-methods.html
-> 공식문서 한번 읽어보시면 좋을것 같아여
- @Query 어노테이션을 달까하다가..! 보통은 findBy~ 커스텀 할때 달더라구요. 제가 필요했던건 핀 설정 update로직이라 그냥 Query클래스 썼습니다.
- ReactiveMongoTemplate도 하나 만들었는데요! 어차피 핀설정하는게 특정 컬럼만 업데이트 하는거자나여 근데 save를 쓰면 모든 document를 바꾼대여 그래서 성능상 업데이트가 나을것 같아서 해당 방식을 사용했어여. 어차피 카테고리는uuid는 유일하니까 해당 조건을 만족하는 첫번째 
값을 바꾸는 updateFirst를 사용해도 무방해보였습니다.
+) 근데 성능은 save나 updateFirst나 비슷하다고 하네여 ㅎㅋㅎㅋㅎ ㅠㅠ

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).