### PR TITLE
refactor : 카카오 로그인 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ repositories {
     mavenCentral()
 }
 
+def os = org.gradle.internal.os.OperatingSystem.current()
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -42,6 +44,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.2'
 
 
+    //mac 설정
+    if (os.isMacOsX()) {
+        runtimeOnly "io.netty:netty-resolver-dns-native-macos:4.1.109.Final:osx-aarch_64"
+    }
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/usememo/jugger/domain/user/entity/User.java
+++ b/src/main/java/com/usememo/jugger/domain/user/entity/User.java
@@ -8,11 +8,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import lombok.ToString;
 
 @Document(collection = "users")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Getter
+@ToString
 public class User {
 	@Id
 	private String uuid;

--- a/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
+++ b/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
@@ -3,17 +3,35 @@ package com.usememo.jugger.global.exception;
 import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-	CATEGORY_ALREADY_EXIST(BAD_REQUEST, 400, "이미 존재하는 카테고리입니다"),
-	CATEGORY_IS_NULL(BAD_REQUEST, 400, "카테고리는 NULL값일 수 없습니다"),
-	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 500, "S3 파일 업로드에 실패했습니다."),
-	NO_REFRESH_TOKEN(UNAUTHORIZED,400,"리프레시 토큰이 없습니다."),
-	EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,400, "만료된 토큰입니다"),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다.");
+
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다."),
+	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 501, "S3 파일 업로드에 실패했습니다."),
+	CATEGORY_ALREADY_EXIST(BAD_REQUEST, 400, "이미 존재하는 카테고리입니다."),
+	CATEGORY_IS_NULL(BAD_REQUEST, 401, "카테고리는 NULL값일 수 없습니다."),
+	NO_REFRESH_TOKEN(UNAUTHORIZED, 402, "리프레시 토큰이 없습니다."),
+	EXPIRED_REFRESH_TOKEN(UNAUTHORIZED, 403, "만료된 토큰입니다."),
+	KAKAO_TOKEN_REQUEST_FAILED(BAD_REQUEST, 410, "카카오 인가 코드로 토큰을 요청하는 데 실패했습니다."),
+	KAKAO_TOKEN_MISSING(BAD_REQUEST, 411, "카카오에서 access_token을 받지 못했습니다."),
+	KAKAO_USERINFO_REQUEST_FAILED(BAD_REQUEST, 412, "카카오 사용자 정보를 가져오는 데 실패했습니다."),
+	KAKAO_USERINFO_INCOMPLETE(BAD_REQUEST, 413, "카카오 사용자 정보가 불완전합니다."),
+	KAKAO_EMAIL_MISSING(BAD_REQUEST, 414, "카카오 응답에 이메일이 존재하지 않습니다."),
+	KAKAO_NAME_MISSING(BAD_REQUEST, 415, "카카오 응답에 닉네임이 존재하지 않습니다."),
+	KAKAO_ACCESS_TOKEN_EMPTY(UNAUTHORIZED, 416, "카카오 access token이 비어 있습니다."),
+	KAKAO_INVALID_AUTH_CODE(BAD_REQUEST, 417, "카카오 인가 코드가 유효하지 않습니다."),
+	KAKAO_CONNECTION_FAILED(BAD_GATEWAY, 418, "카카오 API 서버와 통신에 실패했습니다."),
+	KAKAO_JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 419, "카카오 응답 JSON 파싱에 실패했습니다."),
+	KAKAO_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 420, "카카오 로그인 중 알 수 없는 오류가 발생했습니다."),
+	KAKAO_JWT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 421, "카카오 jwt 토큰 제공시 에러"),
+
+	JWT_KEY_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 422, "JWT 키 생성에 실패했습니다."),
+	JWT_ACCESS_TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 423, "액세스 토큰 생성 실패"),
+	JWT_REFRESH_TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 424, "리프레시 토큰 생성 실패"),
+	JWT_PARSE_FAILED(HttpStatus.UNAUTHORIZED, 425, "JWT 파싱 실패"),
+	JWT_BUNDLE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 426, "JWT 번들 생성 실패");
 
 	private final HttpStatus httpStatus;
 	private final int code;
@@ -24,5 +42,4 @@ public enum ErrorCode {
 		this.code = code;
 		this.message = message;
 	}
-
 }

--- a/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
@@ -43,18 +43,14 @@ public class JwtTokenProvider {
 	@PostConstruct
 	public void init() {
 		try {
-			log.info("🔐 JWT 키 초기화 시작");
 			this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-			log.info("✅ JWT 키 초기화 완료");
 		} catch (Exception e) {
-			log.error("❌ JWT 키 생성 실패", e);
 			throw new BaseException(ErrorCode.JWT_KEY_GENERATION_FAILED);
 		}
 	}
 
 	public String createAccessToken(String userId) {
 		try {
-			log.info("🔐 accessToken 생성 시도 - userId: {}", userId);
 			Date now = new Date();
 			Date expiry = new Date(now.getTime() + accessTokenDuration.toMillis());
 
@@ -64,18 +60,14 @@ public class JwtTokenProvider {
 				.expiration(expiry)
 				.signWith(key, alg)
 				.compact();
-
-			log.info("✅ accessToken 생성 완료");
 			return token;
 		} catch (Exception e) {
-			log.error("❌ accessToken 생성 실패", e);
 			throw new BaseException(ErrorCode.JWT_ACCESS_TOKEN_CREATION_FAILED);
 		}
 	}
 
 	public String createRefreshToken(String userId) {
 		try {
-			log.info("🔄 refreshToken 생성 시도 - userId: {}", userId);
 			Date now = new Date();
 			Date expiry = new Date(now.getTime() + refreshTokenDuration.toMillis());
 
@@ -85,28 +77,21 @@ public class JwtTokenProvider {
 				.expiration(expiry)
 				.signWith(key, alg)
 				.compact();
-
-			log.info("✅ refreshToken 생성 완료");
 			return token;
 		} catch (Exception e) {
-			log.error("❌ refreshToken 생성 실패", e);
 			throw new BaseException(ErrorCode.JWT_REFRESH_TOKEN_CREATION_FAILED);
 		}
 	}
 
 	public String getUserIdFromToken(String token) {
 		try {
-			log.info("🔍 토큰에서 userId 추출 시도");
-			String userId = Jwts.parser()
+			return Jwts.parser()
 				.verifyWith(key)
 				.build()
 				.parseSignedClaims(token)
 				.getPayload()
 				.getSubject();
-			log.info("✅ 추출된 userId: {}", userId);
-			return userId;
 		} catch (JwtException e) {
-			log.error("❌ 토큰 파싱 실패", e);
 			throw new BaseException(ErrorCode.JWT_PARSE_FAILED);
 		}
 	}
@@ -119,20 +104,16 @@ public class JwtTokenProvider {
 				.parseSignedClaims(token);
 			return true;
 		} catch (Exception e) {
-			log.warn("⚠️ 토큰 검증 실패", e);
 			return false;
 		}
 	}
 
 	public TokenResponse createTokenBundle(String userId) {
-		log.info("📦 토큰 번들 생성 시도 - userId: {}", userId);
 		try {
 			String accessToken = createAccessToken(userId);
 			String refreshToken = createRefreshToken(userId);
-			log.info("✅ 토큰 번들 생성 완료");
 			return new TokenResponse(accessToken, refreshToken);
 		} catch (Exception e) {
-			log.error("❌ 토큰 번들 생성 실패", e);
 			throw new BaseException(ErrorCode.JWT_BUNDLE_CREATION_FAILED);
 		}
 	}

--- a/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/usememo/jugger/global/security/JwtTokenProvider.java
@@ -4,24 +4,26 @@ import static io.jsonwebtoken.security.Keys.*;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.MacAlgorithm;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.crypto.SecretKey;
 
+import com.usememo.jugger.global.exception.BaseException;
+import com.usememo.jugger.global.exception.ErrorCode;
 import com.usememo.jugger.global.security.token.domain.TokenResponse;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
@@ -40,41 +42,73 @@ public class JwtTokenProvider {
 
 	@PostConstruct
 	public void init() {
-		this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+		try {
+			log.info("🔐 JWT 키 초기화 시작");
+			this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+			log.info("✅ JWT 키 초기화 완료");
+		} catch (Exception e) {
+			log.error("❌ JWT 키 생성 실패", e);
+			throw new BaseException(ErrorCode.JWT_KEY_GENERATION_FAILED);
+		}
 	}
 
 	public String createAccessToken(String userId) {
-		Date now = new Date();
-		Date expiry = new Date(now.getTime() + accessTokenDuration.toMillis());
+		try {
+			log.info("🔐 accessToken 생성 시도 - userId: {}", userId);
+			Date now = new Date();
+			Date expiry = new Date(now.getTime() + accessTokenDuration.toMillis());
 
-		return Jwts.builder()
-			.claims(Map.of("sub",userId))
-			.issuedAt(now)
-			.expiration(expiry)
-			.signWith(key, alg)
-			.compact();
+			String token = Jwts.builder()
+				.claims(Map.of("sub", userId))
+				.issuedAt(now)
+				.expiration(expiry)
+				.signWith(key, alg)
+				.compact();
+
+			log.info("✅ accessToken 생성 완료");
+			return token;
+		} catch (Exception e) {
+			log.error("❌ accessToken 생성 실패", e);
+			throw new BaseException(ErrorCode.JWT_ACCESS_TOKEN_CREATION_FAILED);
+		}
 	}
 
 	public String createRefreshToken(String userId) {
-		Date now = new Date();
-		Date expiry = new Date(now.getTime() + refreshTokenDuration.toMillis());
+		try {
+			log.info("🔄 refreshToken 생성 시도 - userId: {}", userId);
+			Date now = new Date();
+			Date expiry = new Date(now.getTime() + refreshTokenDuration.toMillis());
 
+			String token = Jwts.builder()
+				.claims(Map.of("sub", userId))
+				.issuedAt(now)
+				.expiration(expiry)
+				.signWith(key, alg)
+				.compact();
 
-		return Jwts.builder()
-			.claims(Map.of("sub",userId))
-			.issuedAt(now)
-			.expiration(expiry)
-			.signWith(key, alg)
-			.compact();
+			log.info("✅ refreshToken 생성 완료");
+			return token;
+		} catch (Exception e) {
+			log.error("❌ refreshToken 생성 실패", e);
+			throw new BaseException(ErrorCode.JWT_REFRESH_TOKEN_CREATION_FAILED);
+		}
 	}
 
 	public String getUserIdFromToken(String token) {
-		return Jwts.parser()
-			.verifyWith(key)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.getSubject();
+		try {
+			log.info("🔍 토큰에서 userId 추출 시도");
+			String userId = Jwts.parser()
+				.verifyWith(key)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload()
+				.getSubject();
+			log.info("✅ 추출된 userId: {}", userId);
+			return userId;
+		} catch (JwtException e) {
+			log.error("❌ 토큰 파싱 실패", e);
+			throw new BaseException(ErrorCode.JWT_PARSE_FAILED);
+		}
 	}
 
 	public boolean validateToken(String token) {
@@ -85,11 +119,21 @@ public class JwtTokenProvider {
 				.parseSignedClaims(token);
 			return true;
 		} catch (Exception e) {
+			log.warn("⚠️ 토큰 검증 실패", e);
 			return false;
 		}
 	}
 
 	public TokenResponse createTokenBundle(String userId) {
-		return new TokenResponse(createAccessToken(userId), createRefreshToken(userId));
+		log.info("📦 토큰 번들 생성 시도 - userId: {}", userId);
+		try {
+			String accessToken = createAccessToken(userId);
+			String refreshToken = createRefreshToken(userId);
+			log.info("✅ 토큰 번들 생성 완료");
+			return new TokenResponse(accessToken, refreshToken);
+		} catch (Exception e) {
+			log.error("❌ 토큰 번들 생성 실패", e);
+			throw new BaseException(ErrorCode.JWT_BUNDLE_CREATION_FAILED);
+		}
 	}
 }

--- a/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.usememo.jugger.global.security.token.controller;
 
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -8,12 +9,14 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.usememo.jugger.domain.user.repository.UserRepository;
 import com.usememo.jugger.global.security.JwtTokenProvider;
+import com.usememo.jugger.global.security.token.domain.KakaoLoginRequest;
 import com.usememo.jugger.global.security.token.domain.TokenResponse;
 import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
 import com.usememo.jugger.global.security.token.service.KakaoOAuthService;
@@ -85,8 +88,8 @@ public class AuthController {
 
 	@Operation(summary = "[POST] 카카오 로그인")
 	@PostMapping("/kakao")
-	public Mono<ResponseEntity<TokenResponse>> loginByKakao(@RequestParam String code) {
-		return kakaoService.loginWithKakao(code)
+	public Mono<ResponseEntity<TokenResponse>> loginByKakao(@RequestBody KakaoLoginRequest request) {
+		return kakaoService.loginWithKakao(request.code())
 			.map(token -> ResponseEntity.ok().body(token));
 	}
 

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoLoginRequest.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoLoginRequest.java
@@ -1,0 +1,8 @@
+package com.usememo.jugger.global.security.token.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record KakaoLoginRequest (
+	@Schema(description = "카카오 인가 코드", example = "dY94g8JaZ1Ki1s...")
+	String code){
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoUserResponse.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoUserResponse.java
@@ -1,21 +1,25 @@
 package com.usememo.jugger.global.security.token.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Getter;
 import lombok.Setter;
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Getter
 @Setter
 public class KakaoUserResponse {
 	private Long id;
-	private KakaoAccount kakaoAccount;
+	private KakaoAccount kakao_account;
 	private Properties properties;
 
 	@Getter @Setter
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class KakaoAccount {
 		private String email;
 	}
 
 	@Getter @Setter
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class Properties {
 		private String nickname;
 	}


### PR DESCRIPTION
## #️⃣ Issue Number

- #65 

## 📝 요약(Summary)

카카오 로그인이 제대로 동작하지 않는 것을 알아내게 되어, 수정을 진행하였습니다.
발견한 문제점 : 
 1. 토큰을 암호화하는 변수의 길이가 짧아서 문제 발생 -> 랜덤 문자열 길이를 더 늘려서 해결 + secret에 수정해서 반영함
 2. 카카오로그인을 통해서 user 정보를 가져올 때 JsonIgnore가 없어서 필드를 전부 만족하지 않아서 문제가 발생함 -> Ignore 추가해서 해결
 3. application.yml에 정보가 계층적으로 잘못쓰여있어서 제대로 읽지 못하고 있었습니다 . -> 올바르게 설정하여 해결하였습니다.
 
<img width="1421" alt="스크린샷 2025-05-02 오후 2 35 39" src="https://github.com/user-attachments/assets/bdd0c2cb-aa86-427c-a51d-15bd6869b2ff" />
위의 사진의 요청을 통해서 로그인을 진행해야 합니다.
또한 쩡킹님이 보내주신 것처럼 그 kauth를 이용한 url 에 localhost로 두는게 아니라 application.yml에 설정해둔 redirect_url을 입력해야지 정상 동작합니다. 해당 url에 키값이 들어있는 관계로 카톡으로 보내드리겠습니다.
클라이언트의 요청으로 카카오 로그인에서 한 번 발급받은 code값은 1회용이라 에러가 나더라도 한 번밖에 요청을 할 수 없습니다.


<img width="1047" alt="스크린샷 2025-05-02 오후 2 38 04" src="https://github.com/user-attachments/assets/1b7a8c3e-a4ec-4628-8557-4d607f816736" />
이렇게 제대로 카카오 로그인 동작하는 것 확인하였습니다. 그리고 발생할 수 있는 예외처리를 다 해서 Errorcode에 추가가 좀 많이 되어있습니다.

---------------------------------------------------------------------------------------
### 로그인 방식에 따른 추가 변경 사항입니다.
디스코드에 작성해둔 대로 카카오 로그인을 하였을 때 등록되어 있지 않은 경우 프론트에게 아래 사진과 같이 nickname과 email을 전달해줍니다.
![스크린샷 2025-05-03 오전 2 26 06](https://github.com/user-attachments/assets/0758d255-f17a-446f-bba9-744b52dc332c)


그리고 이제 해당 정보를 통해서 사용자의 회원가입을 쉽게 도와줄 수 있습니다.
또한 이제 회원가입을 따로 구현하려고 합니다.

회원가입 따로 구현해서 notion에 정리해두었고 토큰 발급 제대로 되는 것 확인했습니다!

## 💬 공유사항 to 리뷰어
application.yml 변경하였습니다. 확인 부탁드려요.
build.gradle 변경하였습니다. 쩡킹님이 말씀하신 문제대로 OS가 mac인 경우에 대한 처리를 해두었습니다.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).