### PR TITLE
refactor : 로그아웃 부분 수정

### DIFF
--- a/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
+++ b/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
@@ -35,7 +35,10 @@ public enum ErrorCode {
 	JWT_ACCESS_TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 423, "액세스 토큰 생성 실패"),
 	JWT_REFRESH_TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 424, "리프레시 토큰 생성 실패"),
 	JWT_PARSE_FAILED(HttpStatus.UNAUTHORIZED, 425, "JWT 파싱 실패"),
-	JWT_BUNDLE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 426, "JWT 번들 생성 실패");
+	JWT_BUNDLE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 426, "JWT 번들 생성 실패"),
+
+	NO_LOGOUT_USER(BAD_REQUEST,404,"존재하지 않는 refresh token입니다."),
+	WRONG_LOGOUT(BAD_REQUEST,404,"로그아웃에 실패하였습니다.");
 
 	private final HttpStatus httpStatus;
 	private final int code;

--- a/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
@@ -67,8 +67,7 @@ public class AuthController {
 	public Mono<ResponseEntity<LogOutResponse>> logout(@RequestBody LogOutRequest request) {
 
 		return kakaoService.userLogOut(request.refreshToken())
-			.then(Mono.fromCallable(() -> ResponseEntity.ok().body(new LogOutResponse("로그아웃이 성공적으로 되었습니다."))));
-
+			.thenReturn(ResponseEntity.ok().body(new LogOutResponse("로그아웃이 성공적으로 되었습니다.")));
 	}
 
 

--- a/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
@@ -13,11 +13,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.usememo.jugger.domain.user.repository.UserRepository;
+import com.usememo.jugger.global.exception.BaseException;
 import com.usememo.jugger.global.exception.ErrorCode;
 import com.usememo.jugger.global.exception.KakaoException;
 import com.usememo.jugger.global.security.JwtTokenProvider;
@@ -25,6 +27,10 @@ import com.usememo.jugger.global.security.token.domain.KakaoLoginRequest;
 
 import com.usememo.jugger.global.security.token.domain.KakaoSignUpRequest;
 
+import com.usememo.jugger.global.security.token.domain.LogOutRequest;
+import com.usememo.jugger.global.security.token.domain.LogOutResponse;
+import com.usememo.jugger.global.security.token.domain.NewTokenResponse;
+import com.usememo.jugger.global.security.token.domain.RefreshTokenRequest;
 import com.usememo.jugger.global.security.token.domain.TokenResponse;
 import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
 import com.usememo.jugger.global.security.token.service.KakaoOAuthService;
@@ -44,55 +50,27 @@ public class AuthController {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final KakaoOAuthService kakaoService;
 
-	@Operation(summary = "[POST] refresh token 으로 새로운 access token 발급")
-	@PostMapping(value = "/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
-	public Mono<ResponseEntity<String>> refreshAccessToken(
-		@CookieValue(name = "refresh_token", required = false) String refreshToken) {
-		if (refreshToken == null) {
-			return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("리프레시 토큰이 없습니다"));
+	@Operation(summary = "[POST] refresh token으로 새로운 access token 발급")
+	@PostMapping(value = "/refresh")
+	public Mono<ResponseEntity<NewTokenResponse>> refreshAccessToken(@RequestBody RefreshTokenRequest request) {
+		String refreshToken = request.refreshToken();
+
+		if (refreshToken == null || refreshToken.isBlank()) {
+			throw new BaseException(ErrorCode.NO_REFRESH_TOKEN);
 		}
-		return refreshTokenRepository.findByToken(refreshToken)
-			.flatMap(savedToken -> {
-				if (!jwtTokenProvider.validateToken(savedToken.getToken())) {
-					return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("만료된 리프레시 토큰입니다."));
-				}
-				String userId = jwtTokenProvider.getUserIdFromToken(savedToken.getToken());
-				return userRepository.findById(userId)
-					.map(user -> {
-						String newAccessToken = jwtTokenProvider.createAccessToken(userId);
-						return ResponseEntity.ok().body("{\"accessToken\":\"" + newAccessToken + "\"}");
-					});
-			})
-			.switchIfEmpty(Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("존재하지 않는 리프레시 토큰입니다.")));
+		return kakaoService.giveNewToken(refreshToken);
 	}
+
 
 	@Operation(summary = "[POST] 로그아웃")
 	@PostMapping("/logout")
-	public Mono<ResponseEntity<Void>> logout(
-		@CookieValue(name = "refresh_token", required = false) String refreshToken) {
-		if (refreshToken == null) {
-			return Mono.just(ResponseEntity.noContent().build());
-		}
+	public Mono<ResponseEntity<LogOutResponse>> logout(@RequestBody LogOutRequest request) {
 
-		String userId;
-		try {
-			userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-		} catch (Exception e) {
-			return Mono.just(ResponseEntity.noContent().build());
-		}
-		return refreshTokenRepository.deleteByUserId(UUID.fromString(userId))
-			.thenReturn(ResponseEntity
-				.noContent()
-				.header("Set-Cookie", ResponseCookie.from("refresh_token", "")
-					.httpOnly(true)
-					.secure(true)
-					.path("/")
-					.maxAge(0)
-					.build()
-					.toString()
-				)
-				.build());
+		return kakaoService.userLogOut(request.refreshToken())
+			.then(Mono.fromCallable(() -> ResponseEntity.ok().body(new LogOutResponse("로그아웃이 성공적으로 되었습니다."))));
+
 	}
+
 
 	@Operation(summary = "[POST] 카카오 로그인")
 	@PostMapping("/kakao")

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/LogOutRequest.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/LogOutRequest.java
@@ -1,0 +1,4 @@
+package com.usememo.jugger.global.security.token.domain;
+
+public record LogOutRequest(String refreshToken) {
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/LogOutResponse.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/LogOutResponse.java
@@ -1,0 +1,4 @@
+package com.usememo.jugger.global.security.token.domain;
+
+public record LogOutResponse(String message) {
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/NewTokenResponse.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/NewTokenResponse.java
@@ -1,0 +1,4 @@
+package com.usememo.jugger.global.security.token.domain;
+
+public record NewTokenResponse(String accessToken) {
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/RefreshTokenRequest.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/RefreshTokenRequest.java
@@ -1,0 +1,4 @@
+package com.usememo.jugger.global.security.token.domain;
+
+public record RefreshTokenRequest(String refreshToken) {
+}

--- a/src/main/java/com/usememo/jugger/global/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/repository/RefreshTokenRepository.java
@@ -1,7 +1,5 @@
 package com.usememo.jugger.global.security.token.repository;
 
-import java.util.UUID;
-
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 import com.usememo.jugger.global.security.token.domain.RefreshToken;
@@ -10,5 +8,6 @@ import reactor.core.publisher.Mono;
 
 public interface RefreshTokenRepository extends ReactiveCrudRepository<RefreshToken,String> {
 	Mono<RefreshToken> findByToken(String token);
-	Mono<Void> deleteByUserId(UUID UserId);
+	Mono<Void> deleteByUserId(String UserId);
+	Mono<RefreshToken> findByUserId(String id);
 }

--- a/src/main/java/com/usememo/jugger/global/security/token/service/KakaoOAuthService.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/service/KakaoOAuthService.java
@@ -136,7 +136,7 @@ public class KakaoOAuthService {
 					.build();
 
 				return userRepository.save(user)
-					.flatMap(savedUser -> jwtTokenProvider.createTokenBundle(savedUser.getUuid()));  // flatMap으로 변경
+					.flatMap(savedUser -> jwtTokenProvider.createTokenBundle(savedUser.getUuid()));
 			}));
 	}
 


### PR DESCRIPTION
## #️⃣ Issue Number

- #79 

## 📝 요약(Summary)
로그아웃과 새롭게 토큰을 발급받는 부분이 쿠키를 통해서 전달되고 있어서 body로 refresh token을 받는 형식으로 수정하였습니다.

## 💬 공유사항 to 리뷰어
노션에 해당 기능들 추가해서 올려두었습니다.
아마 추가로 이제 회원정보 수정이랑 회원가입할 때 추가적인 유저정보 저장할 것 같습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).