### PR TITLE
refactor : GlobalException 수정

### DIFF
--- a/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,88 @@
+package com.usememo.jugger.global.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@Order(-2)
+@RequiredArgsConstructor
+public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public Mono<Void> handle(ServerWebExchange exchange, Throwable exception) {
+		ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+		Map<String, Object> response = new HashMap<>();
+		log.error("에러 내용 : ", exception);
+
+		if (exception instanceof KakaoException kakaoEx &&
+			kakaoEx.getErrorCode() == ErrorCode.KAKAO_USER_NOT_FOUND) {
+
+			exchange.getResponse().setStatusCode(HttpStatus.NOT_FOUND);
+			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+			response.put("code", kakaoEx.getErrorCode().getCode());
+			response.put("message", kakaoEx.getMessage());
+			response.put("domain","kakao");
+			response.put("needSignUp", true);
+			response.put("userInfo", kakaoEx.getMaps());
+		} else if (exception instanceof BaseException baseEx) {
+			errorCode = baseEx.getErrorCode();
+
+
+			exchange.getResponse().setStatusCode(errorCode.getHttpStatus());
+			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+			response.put("code", errorCode.getCode());
+			response.put("message", errorCode.getMessage());
+		}else if (exception instanceof IllegalArgumentException) {
+
+			exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+			response.put("code", HttpStatus.BAD_REQUEST.value());
+			response.put("message", "잘못된 요청입니다.");
+
+		}else if (exception instanceof ResponseStatusException statusEx) {
+			exchange.getResponse().setStatusCode(statusEx.getStatusCode());
+			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+			response.put("code", statusEx.getStatusCode().value());
+			response.put("message", statusEx.getReason() != null ? statusEx.getReason() : "오류가 발생했습니다.");
+		}else {
+			exchange.getResponse().setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+			response.put("code", errorCode.getCode());
+			response.put("message", errorCode.getMessage());
+		}
+
+		DataBufferFactory bufferFactory = exchange.getResponse().bufferFactory();
+		try {
+			byte[] bytes = objectMapper.writeValueAsBytes(response);
+			return exchange.getResponse().writeWith(Mono.just(bufferFactory.wrap(bytes)));
+		} catch (Exception e) {
+			byte[] fallback = "예외 처리 중 오류가 발생했습니다.".getBytes(StandardCharsets.UTF_8);
+			return exchange.getResponse().writeWith(Mono.just(bufferFactory.wrap(fallback)));
+		}
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/usememo/jugger/global/s3/controller/S3Controller.java
@@ -3,6 +3,8 @@ package com.usememo.jugger.global.s3.controller;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -11,23 +13,29 @@ import org.springframework.web.bind.annotation.RestController;
 import com.usememo.jugger.domain.photo.dto.PhotoDto;
 import com.usememo.jugger.global.s3.service.S3Service;
 import com.usememo.jugger.global.s3.service.S3ServiceImplementation;
+import com.usememo.jugger.global.security.CustomOAuth2User;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/api/v1/upload")
+@Tag(name = "이미지 업로드 API", description = "이미지 업로드 API에 대한 설명입니다.")
 @RequiredArgsConstructor
 public class S3Controller {
 	private final S3Service s3Service;
 
+	@Operation(description = "[POST] 이미지 업로드")
 	@PostMapping(value = "/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public Mono<ResponseEntity<String>> upload(
 		@RequestPart("file") FilePart file,
-		@RequestPart("category_uuid") String categoryUuid
+		@RequestPart("category_uuid") String categoryUuid,
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User
 	) {
 		PhotoDto dto = PhotoDto.builder()
-			.user_uuid("123456789a")
+			.user_uuid(customOAuth2User.getUserId())
 			.category_uuid(categoryUuid)
 			.filePart(file)
 			.build();


### PR DESCRIPTION
## #️⃣ Issue Number

- #95 

## 📝 요약(Summary)

GlobalExceptionHandler에서 로그를 찍히게 만들었습니다!!
이제 로그도 찍히고, 클라이언트에게 에러코드도 제대로 전달될 것 같습니다!
추가로, 이제 에러 throw할 때 ErrorCode에 생성 후에 BaseException으로 보내는게 좋아보입니다!!


+ S3 이미지 업로드 컨트롤러에서 토큰 값으로 해당 userId에 맞게 업로드하게끔 수정하였습니다 !! 


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

close #95