### PR TITLE
refactor: 전체 채팅 조회시 이미지가 포함된 채팅이 조회 안되는 문제 수정

### DIFF
--- a/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
@@ -1,33 +1,32 @@
 package com.usememo.jugger.global.s3.service;
 
-
-import io.awspring.cloud.s3.S3Template;
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.http.codec.multipart.FilePart;
-import org.springframework.stereotype.Service;
-
-import reactor.core.publisher.Mono;
-
 import java.io.InputStream;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.stereotype.Service;
+
+import com.usememo.jugger.domain.chat.entity.Chat;
+import com.usememo.jugger.domain.chat.repository.ChatRepository;
 import com.usememo.jugger.domain.photo.dto.PhotoDto;
 import com.usememo.jugger.domain.photo.entity.Photo;
 import com.usememo.jugger.domain.photo.repository.PhotoRepository;
 import com.usememo.jugger.global.exception.s3.S3UploadException;
 
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
 @Service
 @RequiredArgsConstructor
-public class S3ServiceImplementation implements S3Service{
+public class S3ServiceImplementation implements S3Service {
 
 	private final S3Template s3Template;
 	private final PhotoRepository photoRepository;
+	private final ChatRepository chatRepository;
 	@Value("${spring.cloud.aws.s3.bucket}")
 	private String bucketName;
-
 
 	public Mono<String> uploadFile(PhotoDto photoDto) {
 		String originalFilename = photoDto.getFilePart().filename();
@@ -54,13 +53,30 @@ public class S3ServiceImplementation implements S3Service{
 			});
 	}
 
-	private Mono<Boolean> savePhoto(String saveUrl,String user_uuid, String category_uuid){
-		return photoRepository.save(Photo.builder()
-				.url(saveUrl)
-				.userUuid(user_uuid)
-				.categoryUuid(category_uuid)
-				.build())
-			.map(saved -> true)
-			.onErrorReturn(false);
+	private Mono<Boolean> savePhoto(String saveUrl, String userUuid, String categoryUuid) {
+		Photo photo = Photo.builder()
+			.photoUuid(UUID.randomUUID().toString())
+			.url(saveUrl)
+			.userUuid(userUuid)
+			.categoryUuid(categoryUuid)
+			.build();
+
+		return photoRepository.save(photo)
+			.flatMap(savedPhoto -> {
+				Chat chat = Chat.builder()
+					.uuid(UUID.randomUUID().toString())
+					.userUuid(userUuid)
+					.categoryUuid(categoryUuid)
+					.data(null)
+					.refs(Chat.Refs.builder()
+						.photoUuid(savedPhoto.getPhotoUuid())
+						.build())
+					.build();
+
+				return chatRepository.save(chat)
+					.thenReturn(true);  // Photo && Chat 모두 성공 → true
+			})
+			.onErrorResume(e -> Mono.just(false));  // Photo || Chat 실패 → false
 	}
+
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#103 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->


- #48 , #20  작업에서 이미지 업로드 기능을 추가했던 것 같은데, 그때 당시 로직에서는 s3에 이미지 업로드 -> url 받아서 Photo 컬렉션에만 저장으로 되어있었어요!
- Chat 컬렉션에도 저장을 해야 이미지가 전체채팅 조회했을때 보일 수 있어서 이미지 업로드시 Photo 컬렉션에 저장한 다음에 Chat컬렉션에도 저장할 수 있게 로직을 일괄 수정했습니다!

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).