### PR TITLE
feat : 이미지 여러 개 업로드 기능

### DIFF
--- a/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
+++ b/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
 
 	NO_LOGOUT_USER(BAD_REQUEST,404,"존재하지 않는 refresh token입니다."),
 	WRONG_LOGOUT(BAD_REQUEST,404,"로그아웃에 실패하였습니다."),
+	UPLOAD_LIMIT(BAD_REQUEST,404,"최대 업로드 개수는 5개입니다."),
 
 	DELETE_ERROR(BAD_REQUEST,404,"전체 게시글 삭제에 문제가 발생하였습니다.");
 

--- a/src/main/java/com/usememo/jugger/global/s3/dto/FileUploadResponse.java
+++ b/src/main/java/com/usememo/jugger/global/s3/dto/FileUploadResponse.java
@@ -1,0 +1,4 @@
+package com.usememo.jugger.global.s3.dto;
+
+public record FileUploadResponse(int code, String message, String url) {
+}

--- a/src/main/java/com/usememo/jugger/global/s3/dto/FilesUploadResponse.java
+++ b/src/main/java/com/usememo/jugger/global/s3/dto/FilesUploadResponse.java
@@ -1,0 +1,15 @@
+package com.usememo.jugger.global.s3.dto;
+
+import java.util.List;
+
+public record FilesUploadResponse(int code, String message, List<Url> urls) {
+	public static FilesUploadResponse of(int code, String message, List<String> urlList) {
+		List<Url> urls = urlList.stream()
+			.map(Url::new)
+			.toList();
+
+		return new FilesUploadResponse(code, message, urls);
+	}
+
+	public record Url(String url) {}
+}

--- a/src/main/java/com/usememo/jugger/global/s3/service/S3Service.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3Service.java
@@ -3,9 +3,14 @@ package com.usememo.jugger.global.s3.service;
 import org.springframework.http.codec.multipart.FilePart;
 
 import com.usememo.jugger.domain.photo.dto.PhotoDto;
+import com.usememo.jugger.global.s3.dto.FilesUploadResponse;
+import com.usememo.jugger.global.security.CustomOAuth2User;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface S3Service {
 	Mono<String> uploadFile(PhotoDto photoDto);
+
+	Mono<FilesUploadResponse> uploadFiles(Flux<FilePart> files, CustomOAuth2User customOAuth2User, String categoryId);
 }

--- a/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
@@ -37,8 +37,8 @@ public class S3ServiceImplementation extends BaseTimeEntity implements S3Service
 	private String bucketName;
 
 	public Mono<FilesUploadResponse> uploadFiles(Flux<FilePart> files, CustomOAuth2User customOAuth2User, String categoryId){
-		long MAX_COUNT = 5; //우선 아직 프론트 분들이랑 애기를 더 안나누고 설정해둔거라 빠르게 변경할 수 있을 것 같아서
-		//하드코딩입니다.
+		long MAX_COUNT = 5;
+
 		String userId = customOAuth2User.getUserId();
 		return files
 			.index()

--- a/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/global/s3/service/S3ServiceImplementation.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import com.usememo.jugger.domain.chat.entity.Chat;
@@ -13,10 +15,13 @@ import com.usememo.jugger.domain.photo.dto.PhotoDto;
 import com.usememo.jugger.domain.photo.entity.Photo;
 import com.usememo.jugger.domain.photo.repository.PhotoRepository;
 import com.usememo.jugger.global.exception.s3.S3UploadException;
+import com.usememo.jugger.global.s3.dto.FilesUploadResponse;
+import com.usememo.jugger.global.security.CustomOAuth2User;
 import com.usememo.jugger.global.utils.BaseTimeEntity;
 
 import io.awspring.cloud.s3.S3Template;
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
@@ -28,6 +33,20 @@ public class S3ServiceImplementation extends BaseTimeEntity implements S3Service
 	private final ChatRepository chatRepository;
 	@Value("${spring.cloud.aws.s3.bucket}")
 	private String bucketName;
+
+	public Mono<FilesUploadResponse> uploadFiles(Flux<FilePart> files, CustomOAuth2User customOAuth2User, String categoryId){
+		String userId = customOAuth2User.getUserId();
+		return files.flatMap(filePart -> {
+			PhotoDto photoDto = PhotoDto.builder()
+				.categoryId(categoryId)
+				.filePart(filePart)
+				.userId(userId)
+				.build();
+			return uploadFile(photoDto);
+		}).collectList()
+			.map(urls ->  FilesUploadResponse.of(200,"이미지 업로드에 성공하였습니다.",urls));
+	}
+
 
 	public Mono<String> uploadFile(PhotoDto photoDto) {
 		String originalFilename = photoDto.getFilePart().filename();


### PR DESCRIPTION
## #️⃣ Issue Number

- #104

## 📝 요약(Summary)

이미지 여러 개 업로드하는 기능 추가해두었습니다. 현재는 최대 5개로 선택해두어서 주석으로 해두었는데, 여기에 적고 주석 지워둘게요
<img width="795" alt="스크린샷 2025-06-24 오전 2 13 40" src="https://github.com/user-attachments/assets/8cf9c550-159c-45f3-868d-b06501d419ba" />

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).