### PR TITLE
feat: 회원탈퇴 soft delete 기능 구현

### DIFF
--- a/src/main/java/com/usememo/jugger/domain/user/LogoutResponse.java
+++ b/src/main/java/com/usememo/jugger/domain/user/LogoutResponse.java
@@ -1,0 +1,4 @@
+package com.usememo.jugger.domain.user;
+
+public record LogoutResponse(long code, String message) {
+}

--- a/src/main/java/com/usememo/jugger/domain/user/controller/UserController.java
+++ b/src/main/java/com/usememo/jugger/domain/user/controller/UserController.java
@@ -6,11 +6,9 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.usememo.jugger.global.exception.BaseException;
-import com.usememo.jugger.global.exception.ErrorCode;
+import com.usememo.jugger.domain.user.service.UserService;
 import com.usememo.jugger.global.security.CustomOAuth2User;
 import com.usememo.jugger.global.security.token.domain.KakaoLogoutResponse;
-import com.usememo.jugger.global.security.token.service.KakaoOAuthService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,13 +20,13 @@ import reactor.core.publisher.Mono;
 @RequestMapping("api/v1/user")
 @Tag(name = "유저 API", description = "회원정보 수정 및 회원탈퇴 API에 대한 설명입니다.")
 public class UserController {
-
-	private final KakaoOAuthService kakaoOAuthService;
+	private final UserService userService;
 
 	@Operation(summary = "[DELETE] 회원탈퇴")
 	@DeleteMapping("/signout")
-	public Mono<ResponseEntity<KakaoLogoutResponse>> deleteUser(@AuthenticationPrincipal CustomOAuth2User customOAuth2User){
-		return kakaoOAuthService.deleteUser(customOAuth2User.getUserId())
-			.then(Mono.fromCallable(() -> ResponseEntity.ok().body(new KakaoLogoutResponse(200,"회원탈퇴에 성공하였습니다."))));
+	public Mono<ResponseEntity<KakaoLogoutResponse>> deleteUser(
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+		return userService.deleteUser(customOAuth2User.getUserId())
+			.then(Mono.fromCallable(() -> ResponseEntity.ok().body(new KakaoLogoutResponse(200, "회원탈퇴에 성공하였습니다."))));
 	}
 }

--- a/src/main/java/com/usememo/jugger/domain/user/controller/UserController.java
+++ b/src/main/java/com/usememo/jugger/domain/user/controller/UserController.java
@@ -6,9 +6,9 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.usememo.jugger.domain.user.LogoutResponse;
 import com.usememo.jugger.domain.user.service.UserService;
 import com.usememo.jugger.global.security.CustomOAuth2User;
-import com.usememo.jugger.global.security.token.domain.KakaoLogoutResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,9 +24,9 @@ public class UserController {
 
 	@Operation(summary = "[DELETE] 회원탈퇴")
 	@DeleteMapping("/signout")
-	public Mono<ResponseEntity<KakaoLogoutResponse>> deleteUser(
+	public Mono<ResponseEntity<LogoutResponse>> deleteUser(
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 		return userService.deleteUser(customOAuth2User.getUserId())
-			.then(Mono.fromCallable(() -> ResponseEntity.ok().body(new KakaoLogoutResponse(200, "회원탈퇴에 성공하였습니다."))));
+			.then(Mono.fromCallable(() -> ResponseEntity.ok().body(new LogoutResponse(200, "회원탈퇴에 성공하였습니다."))));
 	}
 }

--- a/src/main/java/com/usememo/jugger/domain/user/controller/UserController.java
+++ b/src/main/java/com/usememo/jugger/domain/user/controller/UserController.java
@@ -3,10 +3,12 @@ package com.usememo.jugger.domain.user.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.usememo.jugger.domain.user.LogoutResponse;
+import com.usememo.jugger.domain.user.dto.WithdrawalRequest;
 import com.usememo.jugger.domain.user.service.UserService;
 import com.usememo.jugger.global.security.CustomOAuth2User;
 
@@ -25,8 +27,8 @@ public class UserController {
 	@Operation(summary = "[DELETE] 회원탈퇴")
 	@DeleteMapping("/signout")
 	public Mono<ResponseEntity<LogoutResponse>> deleteUser(
-		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-		return userService.deleteUser(customOAuth2User.getUserId())
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody WithdrawalRequest request) {
+		return userService.deleteUser(customOAuth2User.getUserId(), request)
 			.then(Mono.fromCallable(() -> ResponseEntity.ok().body(new LogoutResponse(200, "회원탈퇴에 성공하였습니다."))));
 	}
 }

--- a/src/main/java/com/usememo/jugger/domain/user/dto/WithdrawalRequest.java
+++ b/src/main/java/com/usememo/jugger/domain/user/dto/WithdrawalRequest.java
@@ -1,0 +1,10 @@
+package com.usememo.jugger.domain.user.dto;
+
+import com.usememo.jugger.domain.user.entity.WithdrawalReason;
+
+public record WithdrawalRequest(
+	WithdrawalReason.ReasonCode reasonCode,
+	String reasonDetail
+) {
+}
+

--- a/src/main/java/com/usememo/jugger/domain/user/entity/User.java
+++ b/src/main/java/com/usememo/jugger/domain/user/entity/User.java
@@ -3,16 +3,12 @@ package com.usememo.jugger.domain.user.entity;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.ToString;
 
 @Document(collection = "users")
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 @Getter
 @ToString
 public class User {
@@ -21,6 +17,11 @@ public class User {
 	private String name;
 	private String email;
 	private String domain;
+	private boolean isDeleted = false;
+
+	public void setDeleted(boolean deleted) {
+		isDeleted = deleted;
+	}
 
 	private Terms terms;
 
@@ -30,4 +31,18 @@ public class User {
 		private boolean privacyPolicy;
 		private boolean marketing;
 	}
+
+	public User() {
+	}
+
+	@Builder
+	public User(String uuid, String name, String email, String domain, Terms terms) {
+		this.uuid = uuid;
+		this.name = name;
+		this.email = email;
+		this.domain = domain;
+		this.isDeleted = false;
+		this.terms = terms;
+	}
+
 }

--- a/src/main/java/com/usememo/jugger/domain/user/entity/WithdrawalReason.java
+++ b/src/main/java/com/usememo/jugger/domain/user/entity/WithdrawalReason.java
@@ -1,0 +1,37 @@
+package com.usememo.jugger.domain.user.entity;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.Builder;
+
+@Document(collection = "withdrawal_reasons")
+public class WithdrawalReason {
+
+	@Id
+	private String uuid;
+	private String userUuid;
+	private ReasonCode reasonCode;
+	private String reasonDetail;
+	private Instant withdrawAt;
+
+	public enum ReasonCode {
+		NOT_USED,
+		INCONVENIENT,
+		NO_FEATURE,
+		ETC
+	}
+
+	@Builder
+	public WithdrawalReason(String uuid, String userUuid, ReasonCode reasonCode, String reasonDetail,
+		Instant withdrawAt) {
+		this.uuid = uuid;
+		this.userUuid = userUuid;
+		this.reasonCode = reasonCode;
+		this.reasonDetail = reasonDetail;
+		this.withdrawAt = withdrawAt;
+	}
+}
+

--- a/src/main/java/com/usememo/jugger/domain/user/repository/WithdrawalReasonRepository.java
+++ b/src/main/java/com/usememo/jugger/domain/user/repository/WithdrawalReasonRepository.java
@@ -1,0 +1,8 @@
+package com.usememo.jugger.domain.user.repository;
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+import com.usememo.jugger.domain.user.entity.WithdrawalReason;
+
+public interface WithdrawalReasonRepository extends ReactiveMongoRepository<WithdrawalReason, String> {
+}

--- a/src/main/java/com/usememo/jugger/domain/user/service/UserService.java
+++ b/src/main/java/com/usememo/jugger/domain/user/service/UserService.java
@@ -1,4 +1,8 @@
 package com.usememo.jugger.domain.user.service;
 
-public class UserService {
+import reactor.core.publisher.Mono;
+
+public interface UserService {
+
+	public Mono<Void> deleteUser(String userId);
 }

--- a/src/main/java/com/usememo/jugger/domain/user/service/UserService.java
+++ b/src/main/java/com/usememo/jugger/domain/user/service/UserService.java
@@ -1,8 +1,10 @@
 package com.usememo.jugger.domain.user.service;
 
+import com.usememo.jugger.domain.user.dto.WithdrawalRequest;
+
 import reactor.core.publisher.Mono;
 
 public interface UserService {
 
-	public Mono<Void> deleteUser(String userId);
+	public Mono<Void> deleteUser(String userId, WithdrawalRequest withdrawalRequest);
 }

--- a/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
@@ -1,8 +1,13 @@
 package com.usememo.jugger.domain.user.service;
 
+import java.time.Instant;
+
 import org.springframework.stereotype.Service;
 
+import com.usememo.jugger.domain.user.dto.WithdrawalRequest;
+import com.usememo.jugger.domain.user.entity.WithdrawalReason;
 import com.usememo.jugger.domain.user.repository.UserRepository;
+import com.usememo.jugger.domain.user.repository.WithdrawalReasonRepository;
 import com.usememo.jugger.global.exception.BaseException;
 import com.usememo.jugger.global.exception.ErrorCode;
 import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
@@ -15,14 +20,26 @@ import reactor.core.publisher.Mono;
 public class UserServiceImplementation implements UserService {
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final UserRepository userRepository;
+	private final WithdrawalReasonRepository withdrawalReasonRepository;
 
-	public Mono<Void> deleteUser(String userId) {
-		return userRepository.findById(userId)
+	public Mono<Void> deleteUser(String userId, WithdrawalRequest withdrawalRequest) {
+		Mono<Void> saveReason = withdrawalReasonRepository.save(
+			WithdrawalReason.builder()
+				.userUuid(userId)
+				.reasonCode(withdrawalRequest.reasonCode())
+				.reasonDetail(withdrawalRequest.reasonDetail())
+				.withdrawAt(Instant.now())
+				.build()
+		).then();
+
+		Mono<Void> softDelete = userRepository.findById(userId)
 			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.USER_NOT_FOUND)))
 			.flatMap(user -> {
 				user.setDeleted(true);
 				return userRepository.save(user);
 			})
 			.then(refreshTokenRepository.deleteByUserId(userId));
+
+		return saveReason.then(softDelete);
 	}
 }

--- a/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
@@ -18,7 +18,7 @@ public class UserServiceImplementation implements UserService {
 
 	public Mono<Void> deleteUser(String userId) {
 		return userRepository.findById(userId)
-			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.KAKAO_USER_NOT_FOUND)))
+			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.USER_NOT_FOUND)))
 			.flatMap(user -> {
 				user.setDeleted(true);
 				return userRepository.save(user);

--- a/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
@@ -23,7 +23,6 @@ public class UserServiceImplementation implements UserService {
 				user.setDeleted(true);
 				return userRepository.save(user);
 			})
-			.then(refreshTokenRepository.deleteByUserId(userId))
-			.then();
+			.then(refreshTokenRepository.deleteByUserId(userId));
 	}
 }

--- a/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/user/service/UserServiceImplementation.java
@@ -1,0 +1,29 @@
+package com.usememo.jugger.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.usememo.jugger.domain.user.repository.UserRepository;
+import com.usememo.jugger.global.exception.BaseException;
+import com.usememo.jugger.global.exception.ErrorCode;
+import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImplementation implements UserService {
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final UserRepository userRepository;
+
+	public Mono<Void> deleteUser(String userId) {
+		return userRepository.findById(userId)
+			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.KAKAO_USER_NOT_FOUND)))
+			.flatMap(user -> {
+				user.setDeleted(true);
+				return userRepository.save(user);
+			})
+			.then(refreshTokenRepository.deleteByUserId(userId))
+			.then();
+	}
+}

--- a/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
+++ b/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
@@ -3,6 +3,7 @@ package com.usememo.jugger.global.exception;
 import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 
 @Getter
@@ -11,10 +12,10 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다."),
 	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 501, "S3 파일 업로드에 실패했습니다."),
 
-	NO_CATEGORY(BAD_REQUEST,404,"잘못된 categoryId 입니다."),
-	NO_AUTHORITY(BAD_REQUEST,404,"해당 사용자의 카테고리가 아닙니다."),
-	NO_CHAT(BAD_REQUEST,404,"채팅이 존재하지 않습니다."),
-	NO_PHOTO(BAD_REQUEST,404,"사진이 존재하지 않습니다."),
+	NO_CATEGORY(BAD_REQUEST, 404, "잘못된 categoryId 입니다."),
+	NO_AUTHORITY(BAD_REQUEST, 404, "해당 사용자의 카테고리가 아닙니다."),
+	NO_CHAT(BAD_REQUEST, 404, "채팅이 존재하지 않습니다."),
+	NO_PHOTO(BAD_REQUEST, 404, "사진이 존재하지 않습니다."),
 
 	CATEGORY_ALREADY_EXIST(BAD_REQUEST, 400, "이미 존재하는 카테고리입니다."),
 	CATEGORY_IS_NULL(BAD_REQUEST, 401, "카테고리는 NULL값일 수 없습니다."),
@@ -33,16 +34,14 @@ public enum ErrorCode {
 	KAKAO_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 420, "카카오 로그인 중 알 수 없는 오류가 발생했습니다."),
 	KAKAO_JWT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 421, "카카오 jwt 토큰 제공시 에러"),
 
-	KAKAO_USER_NOT_FOUND(BAD_REQUEST,427,"존재하지 않는 회원입니다."),
+	USER_NOT_FOUND(BAD_REQUEST, 427, "존재하지 않는 회원입니다."),
 
-	DUPLICATE_USER(BAD_REQUEST,428,"중복된 회원정보입니다."),
+	DUPLICATE_USER(BAD_REQUEST, 428, "중복된 회원정보입니다."),
 
-
-	GOOGLE_LOGIN_FAIL(BAD_REQUEST,404,"로그인에 실패하였습니다."),
-	GOOGLE_NO_EMAIL(BAD_REQUEST,404,"이메일이 존재하지 않습니다."),
-	GOOGLE_USER_NOT_FOUND(BAD_REQUEST,404,"구글 유저가 존재하지 않습니다."),
-	GOOGLE_NO_NAME(BAD_REQUEST,404,"이름이 존재하지 않습니다."),
-
+	GOOGLE_LOGIN_FAIL(BAD_REQUEST, 404, "로그인에 실패하였습니다."),
+	GOOGLE_NO_EMAIL(BAD_REQUEST, 404, "이메일이 존재하지 않습니다."),
+	GOOGLE_USER_NOT_FOUND(BAD_REQUEST, 404, "구글 유저가 존재하지 않습니다."),
+	GOOGLE_NO_NAME(BAD_REQUEST, 404, "이름이 존재하지 않습니다."),
 
 	JWT_KEY_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 422, "JWT 키 생성에 실패했습니다."),
 	JWT_ACCESS_TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 423, "액세스 토큰 생성 실패"),
@@ -50,13 +49,13 @@ public enum ErrorCode {
 	JWT_PARSE_FAILED(HttpStatus.UNAUTHORIZED, 425, "JWT 파싱 실패"),
 	JWT_BUNDLE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 426, "JWT 번들 생성 실패"),
 
-	NO_LOGOUT_USER(BAD_REQUEST,404,"존재하지 않는 refresh token입니다."),
-	WRONG_LOGOUT(BAD_REQUEST,404,"로그아웃에 실패하였습니다."),
-	UPLOAD_LIMIT(BAD_REQUEST,404,"최대 업로드 개수는 5개입니다."),
+	NO_LOGOUT_USER(BAD_REQUEST, 404, "존재하지 않는 refresh token입니다."),
+	WRONG_LOGOUT(BAD_REQUEST, 404, "로그아웃에 실패하였습니다."),
+	UPLOAD_LIMIT(BAD_REQUEST, 404, "최대 업로드 개수는 5개입니다."),
 
-	NO_CALENDAR(BAD_REQUEST,404,"해당 조건에 대한 캘린더가 존재하지 않습니다."),
+	NO_CALENDAR(BAD_REQUEST, 404, "해당 조건에 대한 캘린더가 존재하지 않습니다."),
 
-	DELETE_ERROR(BAD_REQUEST,404,"전체 게시글 삭제에 문제가 발생하였습니다.");
+	DELETE_ERROR(BAD_REQUEST, 404, "전체 게시글 삭제에 문제가 발생하였습니다.");
 
 	private final HttpStatus httpStatus;
 	private final int code;

--- a/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/usememo/jugger/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,9 @@
 package com.usememo.jugger.global.exception;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
-
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.buffer.DataBufferFactory;
@@ -13,12 +13,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
-
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -35,26 +34,25 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
 		log.error("에러 내용 : ", exception);
 
 		if (exception instanceof KakaoException kakaoEx &&
-			kakaoEx.getErrorCode() == ErrorCode.KAKAO_USER_NOT_FOUND) {
+			kakaoEx.getErrorCode() == ErrorCode.USER_NOT_FOUND) {
 
 			exchange.getResponse().setStatusCode(HttpStatus.NOT_FOUND);
 			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
 			response.put("code", kakaoEx.getErrorCode().getCode());
 			response.put("message", kakaoEx.getMessage());
-			response.put("domain","kakao");
+			response.put("domain", "kakao");
 			response.put("needSignUp", true);
 			response.put("userInfo", kakaoEx.getMaps());
 		} else if (exception instanceof BaseException baseEx) {
 			errorCode = baseEx.getErrorCode();
-
 
 			exchange.getResponse().setStatusCode(errorCode.getHttpStatus());
 			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
 			response.put("code", errorCode.getCode());
 			response.put("message", errorCode.getMessage());
-		}else if (exception instanceof IllegalArgumentException) {
+		} else if (exception instanceof IllegalArgumentException) {
 
 			exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
 			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
@@ -62,13 +60,13 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
 			response.put("code", HttpStatus.BAD_REQUEST.value());
 			response.put("message", "잘못된 요청입니다.");
 
-		}else if (exception instanceof ResponseStatusException statusEx) {
+		} else if (exception instanceof ResponseStatusException statusEx) {
 			exchange.getResponse().setStatusCode(statusEx.getStatusCode());
 			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
 			response.put("code", statusEx.getStatusCode().value());
 			response.put("message", statusEx.getReason() != null ? statusEx.getReason() : "오류가 발생했습니다.");
-		}else {
+		} else {
 			exchange.getResponse().setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
 			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
 

--- a/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/controller/AuthController.java
@@ -1,45 +1,22 @@
 package com.usememo.jugger.global.security.token.controller;
 
-import static com.fasterxml.jackson.databind.type.LogicalType.*;
-
-import java.util.Map;
-import java.util.UUID;
-import java.util.logging.Logger;
-
-import org.apache.el.parser.Token;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.usememo.jugger.domain.user.repository.UserRepository;
 import com.usememo.jugger.global.exception.BaseException;
 import com.usememo.jugger.global.exception.ErrorCode;
-import com.usememo.jugger.global.exception.KakaoException;
-import com.usememo.jugger.global.security.CustomOAuth2User;
-import com.usememo.jugger.global.security.JwtTokenProvider;
 import com.usememo.jugger.global.security.token.domain.GoogleLoginRequest;
 import com.usememo.jugger.global.security.token.domain.GoogleSignupRequest;
 import com.usememo.jugger.global.security.token.domain.KakaoLoginRequest;
-
-import com.usememo.jugger.global.security.token.domain.KakaoLogoutResponse;
 import com.usememo.jugger.global.security.token.domain.KakaoSignUpRequest;
-
 import com.usememo.jugger.global.security.token.domain.LogOutRequest;
 import com.usememo.jugger.global.security.token.domain.LogOutResponse;
 import com.usememo.jugger.global.security.token.domain.NewTokenResponse;
 import com.usememo.jugger.global.security.token.domain.RefreshTokenRequest;
 import com.usememo.jugger.global.security.token.domain.TokenResponse;
-import com.usememo.jugger.global.security.token.repository.RefreshTokenRepository;
 import com.usememo.jugger.global.security.token.service.GoogleOAuthService;
 import com.usememo.jugger.global.security.token.service.KakaoOAuthService;
 
@@ -57,7 +34,6 @@ public class AuthController {
 	private final KakaoOAuthService kakaoService;
 	private final GoogleOAuthService googleOAuthService;
 
-
 	@Operation(summary = "[POST] refresh token으로 새로운 access token 발급")
 	@PostMapping(value = "/refresh")
 	public Mono<ResponseEntity<NewTokenResponse>> refreshAccessToken(@RequestBody RefreshTokenRequest request) {
@@ -69,7 +45,6 @@ public class AuthController {
 		return kakaoService.giveNewToken(refreshToken);
 	}
 
-
 	@Operation(summary = "[POST] 로그아웃")
 	@PostMapping("/logout")
 	public Mono<ResponseEntity<LogOutResponse>> logout(@RequestBody LogOutRequest request) {
@@ -77,7 +52,6 @@ public class AuthController {
 		return kakaoService.userLogOut(request.refreshToken())
 			.thenReturn(ResponseEntity.ok().body(new LogOutResponse("로그아웃이 성공적으로 되었습니다.")));
 	}
-
 
 	@Operation(summary = "[POST] 카카오 로그인")
 	@PostMapping("/kakao")
@@ -96,17 +70,16 @@ public class AuthController {
 
 	@Operation(summary = "[POST] 구글 로그인")
 	@PostMapping("/google")
-	public Mono<ResponseEntity<TokenResponse>> loginByGoogle(@RequestBody GoogleLoginRequest googleLoginRequest){
+	public Mono<ResponseEntity<TokenResponse>> loginByGoogle(@RequestBody GoogleLoginRequest googleLoginRequest) {
 		return googleOAuthService.loginWithGoogle(googleLoginRequest.code())
 			.map(token -> ResponseEntity.ok().body(token));
 	}
 
-
 	@Operation(summary = "[POST] 구글 회원가입")
 	@PostMapping("/google/signup")
-	public Mono<ResponseEntity<TokenResponse>> signUpGoogle(@RequestBody GoogleSignupRequest googleSignupRequest){
+	public Mono<ResponseEntity<TokenResponse>> signUpGoogle(@RequestBody GoogleSignupRequest googleSignupRequest) {
 		return googleOAuthService.signUpGoogle(googleSignupRequest)
-			.map(token-> ResponseEntity.ok().body(token));
+			.map(token -> ResponseEntity.ok().body(token));
 	}
 
 }

--- a/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoLogoutResponse.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/domain/KakaoLogoutResponse.java
@@ -1,4 +1,0 @@
-package com.usememo.jugger.global.security.token.domain;
-
-public record KakaoLogoutResponse(long code, String message) {
-}

--- a/src/main/java/com/usememo/jugger/global/security/token/service/KakaoOAuthService.java
+++ b/src/main/java/com/usememo/jugger/global/security/token/service/KakaoOAuthService.java
@@ -101,7 +101,7 @@ public class KakaoOAuthService {
 
 		return userRepository.findByEmailAndDomain(email, "kakao")
 			.switchIfEmpty(Mono.defer(() -> {
-				return Mono.error(new KakaoException(ErrorCode.KAKAO_USER_NOT_FOUND,
+				return Mono.error(new KakaoException(ErrorCode.USER_NOT_FOUND,
 					Map.of("email", email, "nickname", name)));
 			}));
 	}


### PR DESCRIPTION
## #️⃣ Issue Number

- #147 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- UserService에 회원탈퇴 공통기능을 추가하여,
컴포지션 방식으로 카카오, 애플, 구글, 네이버 로그인에서 회원탈퇴 메서드를 가져다 쓰는 방식을 구현했습니다.

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 탈퇴 시 사용자의 삭제 상태를 표시하는 기능이 추가되었습니다.
  * 회원 탈퇴 요청 시 탈퇴 사유를 함께 전달할 수 있도록 개선되었습니다.
  * 회원 탈퇴 응답 메시지 형식이 개선되어 일관된 로그아웃 응답을 제공합니다.
  * 탈퇴 사유 저장 및 관리 기능이 추가되었습니다.

* **버그 수정**
  * 회원 탈퇴 과정에서 사용자 정보와 연관된 토큰이 정상적으로 삭제되도록 개선되었습니다.

* **리팩터링**
  * 서비스 구조가 개선되어 사용자 삭제 로직이 명확하게 분리되고 인터페이스 기반으로 변경되었습니다.

* **스타일**
  * 불필요한 코드와 주석, 사용하지 않는 import가 정리되고 코드 포맷이 일관되게 개선되었습니다.
  * 에러 코드 명칭이 통일되어 사용자 관련 오류 처리의 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->