### PR TITLE
refactor: 카테고리id 없이 수정할수 있게끔 변경

### DIFF
--- a/src/main/java/com/usememo/jugger/domain/calendar/dto/CalendarUpdateRequest.java
+++ b/src/main/java/com/usememo/jugger/domain/calendar/dto/CalendarUpdateRequest.java
@@ -2,5 +2,6 @@ package com.usememo.jugger.domain.calendar.dto;
 
 import java.time.Instant;
 
-public record CalendarUpdateRequest(String calendarId, String categoryId, Instant start, Instant end, String title, String description, String place , Instant alarm) {
+public record CalendarUpdateRequest(String calendarId, Instant start, Instant end, String title, String description,
+									String place, Instant alarm) {
 }

--- a/src/main/java/com/usememo/jugger/domain/calendar/service/CalendarServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/calendar/service/CalendarServiceImplementation.java
@@ -5,9 +5,9 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.usememo.jugger.domain.calendar.dto.CalendarUpdateRequest;
 import com.usememo.jugger.domain.calendar.dto.GetCalendarDto;
 import com.usememo.jugger.domain.calendar.dto.PostCalendarDto;
-import com.usememo.jugger.domain.calendar.dto.CalendarUpdateRequest;
 import com.usememo.jugger.domain.calendar.entity.Calendar;
 import com.usememo.jugger.domain.calendar.repository.CalendarRepository;
 import com.usememo.jugger.domain.category.repository.CategoryRepository;
@@ -84,8 +84,10 @@ public class CalendarServiceImplementation implements CalendarService {
 	}
 
 	@Override
-	public Flux<GetCalendarDto> getCalendarWithCategory(String categoryId,Instant start, Instant end, CustomOAuth2User customOAuth2User ){
-		return calendarRepository.findByUserUuidAndCategoryUuidAndStartDateTimeBetween(customOAuth2User.getUserId(),categoryId, start, end)
+	public Flux<GetCalendarDto> getCalendarWithCategory(String categoryId, Instant start, Instant end,
+		CustomOAuth2User customOAuth2User) {
+		return calendarRepository.findByUserUuidAndCategoryUuidAndStartDateTimeBetween(customOAuth2User.getUserId(),
+				categoryId, start, end)
 			.flatMap(calendar ->
 				categoryRepository.findByUuid(calendar.getCategoryUuid())
 					.map(category -> GetCalendarDto.builder()
@@ -103,7 +105,6 @@ public class CalendarServiceImplementation implements CalendarService {
 			);
 	}
 
-
 	@Override
 	public Mono<BaseResponse> updateCalendar(CustomOAuth2User customOAuth2User, CalendarUpdateRequest request) {
 
@@ -112,7 +113,6 @@ public class CalendarServiceImplementation implements CalendarService {
 			.flatMap(calendar -> {
 				calendar.setTitle(request.title());
 				calendar.setAlarm(request.alarm());
-				calendar.setCategoryUuid(request.categoryId());
 				calendar.setDescription(request.description());
 				calendar.setStartDateTime(request.start());
 				calendar.setEndDateTime(request.end());

--- a/src/main/java/com/usememo/jugger/domain/link/dto/LinkUpdateRequest.java
+++ b/src/main/java/com/usememo/jugger/domain/link/dto/LinkUpdateRequest.java
@@ -1,4 +1,4 @@
 package com.usememo.jugger.domain.link.dto;
 
-public record LinkUpdateRequest(String linkId, String categoryId, String url) {
+public record LinkUpdateRequest(String linkId, String url) {
 }

--- a/src/main/java/com/usememo/jugger/domain/photo/dto/PhotoUpdateRequest.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/dto/PhotoUpdateRequest.java
@@ -1,4 +1,4 @@
 package com.usememo.jugger.domain.photo.dto;
 
-public record PhotoUpdateRequest(String photoId, String categoryId, String description) {
+public record PhotoUpdateRequest(String photoId, String description) {
 }

--- a/src/main/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementation.java
@@ -99,7 +99,7 @@ public class PhotoServiceImplementation implements PhotoService {
 	public Mono<BaseResponse> updatePhotoDescription(CustomOAuth2User customOAuth2User, PhotoUpdateRequest request) {
 		Query query = Query.query(
 			Criteria.where("uuid").is(request.photoId())
-				.and("userUuid").is(customOAuth2User.getUserId())
+				.and("user_uuid").is(customOAuth2User.getUserId())
 		);
 
 		Update update = new Update().set("description", request.description());

--- a/src/main/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementation.java
@@ -6,10 +6,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
-import com.usememo.jugger.domain.photo.dto.PhotoResponse;
 import com.usememo.jugger.domain.photo.dto.GetPhotoRequestDto;
+import com.usememo.jugger.domain.photo.dto.PhotoResponse;
 import com.usememo.jugger.domain.photo.dto.PhotoUpdateRequest;
 import com.usememo.jugger.domain.photo.entity.Photo;
 import com.usememo.jugger.domain.photo.repository.PhotoRepository;
@@ -34,50 +35,25 @@ public class PhotoServiceImplementation implements PhotoService {
 	@Override
 	public Flux<PhotoResponse> getPhotoDto(GetPhotoRequestDto photoRequestDto, CustomOAuth2User customOAuth2User) {
 		return photoRepository
-					.findByUserUuidAndCategoryUuid(customOAuth2User.getUserId(), photoRequestDto.getCategoryId())
-					.map(photo -> PhotoResponse.builder()
-						.photoId(photo.getId())
-						.url(photo.getUrl())
-						.categoryId(photo.getCategoryUuid())
-						.description(photo.getDescription())
-						.timestamp(photo.getUpdatedAt())
-						.build());
+			.findByUserUuidAndCategoryUuid(customOAuth2User.getUserId(), photoRequestDto.getCategoryId())
+			.map(photo -> PhotoResponse.builder()
+				.photoId(photo.getId())
+				.url(photo.getUrl())
+				.categoryId(photo.getCategoryUuid())
+				.description(photo.getDescription())
+				.timestamp(photo.getUpdatedAt())
+				.build());
 	}
 
 	@Override
-	public Flux<PhotoResponse> getPhotoDuration(Instant before, int page, int size, CustomOAuth2User customOAuth2User){
+	public Flux<PhotoResponse> getPhotoDuration(Instant before, int page, int size, CustomOAuth2User customOAuth2User) {
 		String userId = customOAuth2User.getUserId();
 
 		Query query = new Query()
 			.addCriteria(Criteria.where("user_uuid").is(userId))
 			.addCriteria(Criteria.where("created_at").lt(before))
 			.with(Sort.by(Sort.Direction.DESC, "created_at"))
-			.skip((long) page * size)
-			.limit(size);
-
-		return reactiveMongoTemplate.find(query, Photo.class)
-					.map(photo ->
-							 PhotoResponse.builder()
-								 .photoId(photo.getId())
-								.url(photo.getUrl())
-								.categoryId(photo.getCategoryUuid())
-								.timestamp(photo.getUpdatedAt())
-								.description(photo.getDescription())
-								.build()
-					);
-
-	}
-
-	@Override
-	public Flux<PhotoResponse> getPhotoCategoryAndDuration(String categoryId, Instant before, int page, int size, CustomOAuth2User customOAuth2User){
-		String userId = customOAuth2User.getUserId();
-
-		Query query = new Query()
-			.addCriteria(Criteria.where("user_uuid").is(userId))
-			.addCriteria(Criteria.where("category_uuid").is(categoryId))
-			.addCriteria(Criteria.where("created_at").lt(before))
-			.with(Sort.by(Sort.Direction.DESC, "created_at"))
-			.skip((long) page * size)
+			.skip((long)page * size)
 			.limit(size);
 
 		return reactiveMongoTemplate.find(query, Photo.class)
@@ -94,18 +70,48 @@ public class PhotoServiceImplementation implements PhotoService {
 	}
 
 	@Override
-	public Mono<BaseResponse> updatePhotoDescription(CustomOAuth2User customOAuth2User, PhotoUpdateRequest request){
+	public Flux<PhotoResponse> getPhotoCategoryAndDuration(String categoryId, Instant before, int page, int size,
+		CustomOAuth2User customOAuth2User) {
+		String userId = customOAuth2User.getUserId();
 
-		return photoRepository.findByUuidAndUserUuid(request.photoId(), customOAuth2User.getUserId())
-			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_PHOTO)))
-			.flatMap(photo -> {
+		Query query = new Query()
+			.addCriteria(Criteria.where("user_uuid").is(userId))
+			.addCriteria(Criteria.where("category_uuid").is(categoryId))
+			.addCriteria(Criteria.where("created_at").lt(before))
+			.with(Sort.by(Sort.Direction.DESC, "created_at"))
+			.skip((long)page * size)
+			.limit(size);
 
-				photo.setCategoryUuid(request.categoryId());
-				photo.setDescription(request.description());
-				return photoRepository.save(photo);
-				}).thenReturn(new BaseResponse(200,"사진을 수정하였습니다."));
+		return reactiveMongoTemplate.find(query, Photo.class)
+			.map(photo ->
+				PhotoResponse.builder()
+					.photoId(photo.getId())
+					.url(photo.getUrl())
+					.categoryId(photo.getCategoryUuid())
+					.timestamp(photo.getUpdatedAt())
+					.description(photo.getDescription())
+					.build()
+			);
 
 	}
 
+	@Override
+	public Mono<BaseResponse> updatePhotoDescription(CustomOAuth2User customOAuth2User, PhotoUpdateRequest request) {
+		Query query = Query.query(
+			Criteria.where("uuid").is(request.photoId())
+				.and("userUuid").is(customOAuth2User.getUserId())
+		);
+
+		Update update = new Update().set("description", request.description());
+
+		return reactiveMongoTemplate.updateFirst(query, update, Photo.class)
+			.flatMap(result -> {
+				if (result.getMatchedCount() == 0) {
+					return Mono.error(new BaseException(ErrorCode.NO_PHOTO));
+				}
+				return Mono.just(new BaseResponse(200, "사진을 수정하였습니다."));
+			});
+
+	}
 
 }

--- a/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
+++ b/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
@@ -3,6 +3,7 @@ package com.usememo.jugger.global.exception;
 import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 
 @Getter
@@ -11,10 +12,10 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다."),
 	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 501, "S3 파일 업로드에 실패했습니다."),
 
-	NO_CATEGORY(BAD_REQUEST,404,"잘못된 categoryId 입니다."),
-	NO_AUTHORITY(BAD_REQUEST,404,"해당 사용자의 카테고리가 아닙니다."),
-	NO_CHAT(BAD_REQUEST,404,"채팅이 존재하지 않습니다."),
-	NO_PHOTO(BAD_REQUEST,404,"사진이 존재하지 않습니다."),
+	NO_CATEGORY(BAD_REQUEST, 404, "잘못된 categoryId 입니다."),
+	NO_AUTHORITY(BAD_REQUEST, 404, "해당 사용자의 카테고리가 아닙니다."),
+	NO_CHAT(BAD_REQUEST, 404, "채팅이 존재하지 않습니다."),
+	NO_PHOTO(BAD_REQUEST, 404, "사진이 존재하지 않습니다."),
 
 	CATEGORY_ALREADY_EXIST(BAD_REQUEST, 400, "이미 존재하는 카테고리입니다."),
 	CATEGORY_IS_NULL(BAD_REQUEST, 401, "카테고리는 NULL값일 수 없습니다."),
@@ -33,16 +34,14 @@ public enum ErrorCode {
 	KAKAO_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 420, "카카오 로그인 중 알 수 없는 오류가 발생했습니다."),
 	KAKAO_JWT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 421, "카카오 jwt 토큰 제공시 에러"),
 
-	KAKAO_USER_NOT_FOUND(BAD_REQUEST,427,"존재하지 않는 회원입니다."),
+	KAKAO_USER_NOT_FOUND(BAD_REQUEST, 427, "존재하지 않는 회원입니다."),
 
-	DUPLICATE_USER(BAD_REQUEST,428,"중복된 회원정보입니다."),
+	DUPLICATE_USER(BAD_REQUEST, 428, "중복된 회원정보입니다."),
 
-
-	GOOGLE_LOGIN_FAIL(BAD_REQUEST,404,"로그인에 실패하였습니다."),
-	GOOGLE_NO_EMAIL(BAD_REQUEST,404,"이메일이 존재하지 않습니다."),
-	GOOGLE_USER_NOT_FOUND(BAD_REQUEST,404,"구글 유저가 존재하지 않습니다."),
-	GOOGLE_NO_NAME(BAD_REQUEST,404,"이름이 존재하지 않습니다."),
-
+	GOOGLE_LOGIN_FAIL(BAD_REQUEST, 404, "로그인에 실패하였습니다."),
+	GOOGLE_NO_EMAIL(BAD_REQUEST, 404, "이메일이 존재하지 않습니다."),
+	GOOGLE_USER_NOT_FOUND(BAD_REQUEST, 404, "구글 유저가 존재하지 않습니다."),
+	GOOGLE_NO_NAME(BAD_REQUEST, 404, "이름이 존재하지 않습니다."),
 
 	JWT_KEY_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 422, "JWT 키 생성에 실패했습니다."),
 	JWT_ACCESS_TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 423, "액세스 토큰 생성 실패"),
@@ -50,13 +49,13 @@ public enum ErrorCode {
 	JWT_PARSE_FAILED(HttpStatus.UNAUTHORIZED, 425, "JWT 파싱 실패"),
 	JWT_BUNDLE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 426, "JWT 번들 생성 실패"),
 
-	NO_LOGOUT_USER(BAD_REQUEST,404,"존재하지 않는 refresh token입니다."),
-	WRONG_LOGOUT(BAD_REQUEST,404,"로그아웃에 실패하였습니다."),
-	UPLOAD_LIMIT(BAD_REQUEST,404,"최대 업로드 개수는 5개입니다."),
+	NO_LOGOUT_USER(BAD_REQUEST, 404, "존재하지 않는 refresh token입니다."),
+	WRONG_LOGOUT(BAD_REQUEST, 404, "로그아웃에 실패하였습니다."),
+	UPLOAD_LIMIT(BAD_REQUEST, 404, "최대 업로드 개수는 5개입니다."),
 
-	NO_CALENDAR(BAD_REQUEST,404,"해당 조건에 대한 캘린더가 존재하지 않습니다."),
-
-	DELETE_ERROR(BAD_REQUEST,404,"전체 게시글 삭제에 문제가 발생하였습니다.");
+	NO_CALENDAR(BAD_REQUEST, 404, "해당 조건에 대한 캘린더가 존재하지 않습니다."),
+	LINK_NOT_FOUND(BAD_REQUEST, 404, "해당 조건에 랑크가 존재하지 않습니다."),
+	DELETE_ERROR(BAD_REQUEST, 404, "전체 게시글 삭제에 문제가 발생하였습니다.");
 
 	private final HttpStatus httpStatus;
 	private final int code;

--- a/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
+++ b/src/main/java/com/usememo/jugger/global/exception/ErrorCode.java
@@ -54,7 +54,7 @@ public enum ErrorCode {
 	UPLOAD_LIMIT(BAD_REQUEST, 404, "최대 업로드 개수는 5개입니다."),
 
 	NO_CALENDAR(BAD_REQUEST, 404, "해당 조건에 대한 캘린더가 존재하지 않습니다."),
-	LINK_NOT_FOUND(BAD_REQUEST, 404, "해당 조건에 랑크가 존재하지 않습니다."),
+	LINK_NOT_FOUND(BAD_REQUEST, 404, "해당 조건에 링크가 존재하지 않습니다."),
 	DELETE_ERROR(BAD_REQUEST, 404, "전체 게시글 삭제에 문제가 발생하였습니다.");
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ Issue Number
- #148 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 링크 수정, 사진 설명 수정, 일정수정하기 하려면 categoryId에 종속됨
- categoryId 종속을 일괄 해제
- 사진 설명 수정의 경우, 기존에 save메서드만 쓰면 uuid가 중복된다고 난리쳐서 mongoTemplate씀

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 일정, 링크, 사진 수정 요청 시 더 이상 카테고리 정보를 입력하지 않도록 변경되었습니다.
  * 링크 수정 시 카테고리 유효성 검사 및 카테고리 변경 기능이 제거되었습니다.
  * 사진 설명 수정 기능이 보다 안정적으로 동작하도록 개선되었습니다.

* **신규 기능**
  * 링크가 존재하지 않을 때 반환되는 에러 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->