### PR TITLE
refactor : chatId로 입력 변경

### DIFF
--- a/src/main/java/com/usememo/jugger/domain/calendar/dto/CalendarUpdateRequest.java
+++ b/src/main/java/com/usememo/jugger/domain/calendar/dto/CalendarUpdateRequest.java
@@ -2,6 +2,6 @@ package com.usememo.jugger.domain.calendar.dto;
 
 import java.time.Instant;
 
-public record CalendarUpdateRequest(String calendarId, Instant start, Instant end, String title, String description,
+public record CalendarUpdateRequest(String chatId, Instant start, Instant end, String title, String description,
 									String place, Instant alarm) {
 }

--- a/src/main/java/com/usememo/jugger/domain/calendar/service/CalendarServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/calendar/service/CalendarServiceImplementation.java
@@ -113,7 +113,7 @@ public class CalendarServiceImplementation implements CalendarService {
 					.flatMap(chat -> {
 						String calendarId = chat.getRefs().getCalendarUuid();
 						if(calendarId.isBlank()){
-							throw new BaseException(ErrorCode.NO_CALENDAR);
+							return Mono.error(new BaseException(ErrorCode.NO_CALENDAR));
 						}
 						return calendarRepository.findByUuidAndUserUuid(calendarId, customOAuth2User.getUserId())
 							.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_CALENDAR)))

--- a/src/main/java/com/usememo/jugger/domain/calendar/service/CalendarServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/calendar/service/CalendarServiceImplementation.java
@@ -108,20 +108,27 @@ public class CalendarServiceImplementation implements CalendarService {
 	@Override
 	public Mono<BaseResponse> updateCalendar(CustomOAuth2User customOAuth2User, CalendarUpdateRequest request) {
 
-		return calendarRepository.findByUuidAndUserUuid(request.calendarId(), customOAuth2User.getUserId())
-			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_CALENDAR)))
-			.flatMap(calendar -> {
-				calendar.setTitle(request.title());
-				calendar.setAlarm(request.alarm());
-				calendar.setDescription(request.description());
-				calendar.setStartDateTime(request.start());
-				calendar.setEndDateTime(request.end());
-				calendar.setPlace(request.place());
+		return chatRepository.findById(request.chatId())
+				.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_CHAT)))
+					.flatMap(chat -> {
+						String calendarId = chat.getRefs().getCalendarUuid();
+						if(calendarId.isBlank()){
+							throw new BaseException(ErrorCode.NO_CALENDAR);
+						}
+						return calendarRepository.findByUuidAndUserUuid(calendarId, customOAuth2User.getUserId())
+							.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_CALENDAR)))
+							.flatMap(calendar -> {
+								calendar.setTitle(request.title());
+								calendar.setAlarm(request.alarm());
+								calendar.setDescription(request.description());
+								calendar.setStartDateTime(request.start());
+								calendar.setEndDateTime(request.end());
+								calendar.setPlace(request.place());
 
-				return calendarRepository.save(calendar)
-					.thenReturn(new BaseResponse(200, "일정이 변경되었습니다."));
-			});
-
+								return calendarRepository.save(calendar)
+									.thenReturn(new BaseResponse(200, "일정이 변경되었습니다."));
+							});
+					});
 	}
 
 }

--- a/src/main/java/com/usememo/jugger/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/usememo/jugger/domain/chat/controller/ChatController.java
@@ -107,7 +107,6 @@ public class ChatController {
 	@Operation(summary = "[PATCH] 채팅 카테고리 변경",description = "채팅의 카테고리를 변경하는데 사용하는 메소드입니다.")
 	@PatchMapping("/category")
 	public Mono<ResponseEntity<ChatResponse>> patchChatCategory(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestParam String chatId, @RequestParam String newCategoryId){
-		//여기도 전체적으로 채팅으로 들어가서 repository로 id를 들어가서 교체하는 과정이 들어가야 한다.
 		return chatService.changeCategory(customOAuth2User, chatId, newCategoryId)
 			.thenReturn(ResponseEntity.ok().body(new ChatResponse(200,"카테고리가 변경되었습니다.")));
 	}

--- a/src/main/java/com/usememo/jugger/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/usememo/jugger/domain/chat/controller/ChatController.java
@@ -107,7 +107,7 @@ public class ChatController {
 	@Operation(summary = "[PATCH] 채팅 카테고리 변경",description = "채팅의 카테고리를 변경하는데 사용하는 메소드입니다.")
 	@PatchMapping("/category")
 	public Mono<ResponseEntity<ChatResponse>> patchChatCategory(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestParam String chatId, @RequestParam String newCategoryId){
-
+		//여기도 전체적으로 채팅으로 들어가서 repository로 id를 들어가서 교체하는 과정이 들어가야 한다.
 		return chatService.changeCategory(customOAuth2User, chatId, newCategoryId)
 			.thenReturn(ResponseEntity.ok().body(new ChatResponse(200,"카테고리가 변경되었습니다.")));
 	}

--- a/src/main/java/com/usememo/jugger/domain/chat/service/ChatServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/chat/service/ChatServiceImplementation.java
@@ -373,36 +373,44 @@ public class ChatServiceImplementation implements ChatService {
 		return chatRepository.findByUuidAndUserUuid(chatId, userId)
 			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_CHAT)))
 			.flatMap(chat -> {
-					chat.setCategoryUuid(newCategoryId);
-					Chat.Refs refs = chat.getRefs();
+				chat.setCategoryUuid(newCategoryId);
+				Chat.Refs refs = chat.getRefs();
 
-					if (refs.getCalendarUuid() != null && !refs.getCalendarUuid().isEmpty()) {
-						String calendarUuid = refs.getCalendarUuid();
-							 calendarRepository.findById(calendarUuid)
-							.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_CALENDAR)))
-							.flatMap(calendar -> {
-								calendar.setCategoryUuid(newCategoryId);
-								return calendarRepository.save(calendar);
-							});
-					} else if (refs.getLinkUuid() != null && !refs.getLinkUuid().isEmpty()) {
-						String linkUuid = refs.getLinkUuid();
-						linkRepository.findById(linkUuid)
-							.switchIfEmpty(Mono.error(new BaseException(ErrorCode.LINK_NOT_FOUND)))
-							.flatMap(link -> {
-								link.setCategoryUuid(newCategoryId);
-								return linkRepository.save(link);
-							});
-					} else if (refs.getPhotoUuid() != null && !refs.getPhotoUuid().isEmpty()) {
-						String photoUuid = refs.getPhotoUuid();
-						photoRepository.findById(photoUuid)
-							.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_PHOTO)))
-							.flatMap(photo -> {
-								photo.setCategoryUuid(newCategoryId);
-								return photoRepository.save(photo);
-							});
-					}
-				return chatRepository.save(chat);})
-			.then();
+				Mono<?> updateMono;
+
+				if (refs.getCalendarUuid() != null && !refs.getCalendarUuid().isEmpty()) {
+					String calendarUuid = refs.getCalendarUuid();
+					updateMono = calendarRepository.findById(calendarUuid)
+						.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_CALENDAR)))
+						.flatMap(calendar -> {
+							calendar.setCategoryUuid(newCategoryId);
+							return calendarRepository.save(calendar);
+						});
+
+				} else if (refs.getLinkUuid() != null && !refs.getLinkUuid().isEmpty()) {
+					String linkUuid = refs.getLinkUuid();
+					updateMono = linkRepository.findById(linkUuid)
+						.switchIfEmpty(Mono.error(new BaseException(ErrorCode.LINK_NOT_FOUND)))
+						.flatMap(link -> {
+							link.setCategoryUuid(newCategoryId);
+							return linkRepository.save(link);
+						});
+
+				} else if (refs.getPhotoUuid() != null && !refs.getPhotoUuid().isEmpty()) {
+					String photoUuid = refs.getPhotoUuid();
+					updateMono = photoRepository.findById(photoUuid)
+						.switchIfEmpty(Mono.error(new BaseException(ErrorCode.NO_PHOTO)))
+						.flatMap(photo -> {
+							photo.setCategoryUuid(newCategoryId);
+							return photoRepository.save(photo);
+						});
+
+				} else {
+					updateMono = Mono.empty();
+				}
+
+				return updateMono.then(chatRepository.save(chat)).then();
+			});
 	}
 
 }

--- a/src/main/java/com/usememo/jugger/domain/chat/service/ChatServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/chat/service/ChatServiceImplementation.java
@@ -365,7 +365,7 @@ public class ChatServiceImplementation implements ChatService {
 			.then();
 	}
 
-	//chat의 카테고리 변경
+
 	@Override
 	public Mono<Void> changeCategory(CustomOAuth2User customOAuth2User, String chatId, String newCategoryId) {
 		String userId = customOAuth2User.getUserId();

--- a/src/main/java/com/usememo/jugger/domain/link/dto/LinkUpdateRequest.java
+++ b/src/main/java/com/usememo/jugger/domain/link/dto/LinkUpdateRequest.java
@@ -1,4 +1,4 @@
 package com.usememo.jugger.domain.link.dto;
 
-public record LinkUpdateRequest(String linkId, String url) {
+public record LinkUpdateRequest(String chatId, String url) {
 }

--- a/src/main/java/com/usememo/jugger/domain/link/service/LinkServiceImplementation.java
+++ b/src/main/java/com/usememo/jugger/domain/link/service/LinkServiceImplementation.java
@@ -115,13 +115,19 @@ public class LinkServiceImplementation implements LinkService {
 	public Mono<LinkResponse> updateLink(CustomOAuth2User customOAuth2User, LinkUpdateRequest request) {
 		String userId = customOAuth2User.getUserId();
 
-		return linkRepository.findByUuidAndUserUuid(request.linkId(), userId)
-			.switchIfEmpty(Mono.error(new BaseException(ErrorCode.LINK_NOT_FOUND)))
-			.flatMap(link -> {
-					link.setUrl(request.url());
-					return linkRepository.save(link);
-				}
-			).thenReturn(new LinkResponse(200, "링크를 수정하였습니다."));
+		return chatRepository.findById(request.chatId())
+				.flatMap(chat ->
+				{
+					String linkId = chat.getRefs().getLinkUuid();
+					return linkRepository.findByUuidAndUserUuid(linkId, userId)
+						.switchIfEmpty(Mono.error(new BaseException(ErrorCode.LINK_NOT_FOUND)))
+						.flatMap(link -> {
+								link.setUrl(request.url());
+								return linkRepository.save(link);
+							}
+						).thenReturn(new LinkResponse(200, "링크를 수정하였습니다."));
+				});
+
 	}
 
 }

--- a/src/main/java/com/usememo/jugger/domain/photo/dto/PhotoUpdateRequest.java
+++ b/src/main/java/com/usememo/jugger/domain/photo/dto/PhotoUpdateRequest.java
@@ -1,4 +1,4 @@
 package com.usememo.jugger.domain.photo.dto;
 
-public record PhotoUpdateRequest(String photoId, String description) {
+public record PhotoUpdateRequest(String chatId, String description) {
 }

--- a/src/test/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementationTest.java
+++ b/src/test/java/com/usememo/jugger/domain/photo/service/PhotoServiceImplementationTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 
 import com.usememo.jugger.domain.category.entity.Category;
 import com.usememo.jugger.domain.category.repository.CategoryRepository;
+import com.usememo.jugger.domain.chat.repository.ChatRepository;
 import com.usememo.jugger.domain.photo.dto.PhotoResponse;
 import com.usememo.jugger.domain.photo.dto.GetPhotoRequestDto;
 import com.usememo.jugger.domain.photo.entity.Photo;
@@ -33,7 +34,8 @@ class PhotoServiceImplementationTest {
 		PhotoRepository photoRepository = mock(PhotoRepository.class);
 		CategoryRepository categoryRepository = mock(CategoryRepository.class);
 		ReactiveMongoTemplate reactiveMongoTemplate = mock(ReactiveMongoTemplate.class);
-		PhotoServiceImplementation photoService = new PhotoServiceImplementation(photoRepository,reactiveMongoTemplate);
+		ChatRepository chatRepository = mock(ChatRepository.class);
+		PhotoServiceImplementation photoService = new PhotoServiceImplementation(photoRepository,reactiveMongoTemplate,chatRepository);
 
 		String userUuid = "123456789a";
 		String categoryUuid = "여행";


### PR DESCRIPTION
## #️⃣ Issue Number

- #146 

## 📝 요약(Summary)
photoId, linkId 등 따로 ID 입력 받는 설계는 잘못된 것 같아서 전부 chatId로 입력받아서 변경할 수 있도록 수정하였습니다!

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅을 통해 캘린더, 링크, 사진의 정보를 업데이트할 수 있도록 개선되었습니다.

* **버그 수정**
  * 채팅의 카테고리 변경 시, 연결된 캘린더, 링크, 사진의 카테고리도 함께 변경됩니다.

* **스타일**
  * 일부 코드 내 불필요한 공백이 제거되었습니다.

* **기타**
  * 여러 업데이트 요청의 필드명이 일관성 있게 변경되었습니다 (`calendarId`, `linkId`, `photoId` → `chatId`).
  * 캘린더, 링크, 사진 업데이트 로직이 채팅 엔티티를 통해 참조 정보를 조회하는 방식으로 변경되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->