### PR TITLE
fix : chatId 리턴하게끔 수정 

### DIFF
--- a/src/main/java/com/usememo/jugger/domain/calendar/dto/GetCalendarDto.java
+++ b/src/main/java/com/usememo/jugger/domain/calendar/dto/GetCalendarDto.java
@@ -4,10 +4,13 @@ import java.time.Instant;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
 
 @Builder
 @Data
 public class GetCalendarDto {
+	@Setter
+	private String chatId;
 	private String calendarId;
 	private Instant startDateTime;
 	private Instant endDateTime;

--- a/src/main/java/com/usememo/jugger/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/usememo/jugger/domain/chat/repository/ChatRepository.java
@@ -28,4 +28,6 @@ public interface ChatRepository extends ReactiveMongoRepository<Chat, String> {
 
 	Mono<Void> deleteByUuidAndUserUuid(String chatId,String userId);
 
+	Mono<Chat> findByRefs_CalendarUuid(String calendarUuid);
+
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #155 

## 📝 요약(Summary)

chatId를 리턴해서 해당 값으로 캘린더 수정가능하게끔 변경하였습니다!
swagger로 테스트해서 정상동작하는 것 확인했습니다!

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 캘린더 정보 조회 시 관련된 채팅 ID(chatId)가 포함되어 제공됩니다.

* **버그 수정**
  * 없음

* **기타 변경**
  * 캘린더와 연결된 채팅 정보를 조회하는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->